### PR TITLE
Fix retry function and syntax issues

### DIFF
--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,50 @@
+import ast
+import pathlib
+import types
+import os
+import time
+import pytest
+
+# Extract retry_until_ready function without importing entire module
+SRC = pathlib.Path("packages/home_index/main.py").read_text()
+module = ast.parse(SRC)
+nodes = []
+for node in module.body:
+    if (
+        isinstance(node, ast.Assign)
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "RETRY_UNTIL_READY_SECONDS"
+    ):
+        nodes.append(node)
+    if isinstance(node, ast.FunctionDef) and node.name == "retry_until_ready":
+        nodes.append(node)
+        break
+assert len(nodes) == 2, "Definitions not found"
+retry_src = ast.Module(body=nodes, type_ignores=[])
+code = compile(retry_src, filename="<retry>", mode="exec")
+ns = {"time": time, "os": os}
+exec(code, ns)
+retry_until_ready = ns["retry_until_ready"]
+
+def test_retry_until_ready_success(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(time, 'sleep', lambda s: sleeps.append(s))
+    attempts = {'c':0}
+    def fn():
+        attempts['c'] += 1
+        if attempts['c'] < 3:
+            raise ValueError('no')
+        return 'ok'
+    result = retry_until_ready(fn, 'fail', seconds=3)
+    assert result == 'ok'
+    assert attempts['c'] == 3
+    assert sleeps == [1,1]
+
+def test_retry_until_ready_failure(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(time, 'sleep', lambda s: sleeps.append(s))
+    def fn():
+        raise ValueError('no')
+    with pytest.raises(RuntimeError):
+        retry_until_ready(fn, 'fail', seconds=2)
+    assert sleeps == [1]


### PR DESCRIPTION
## Summary
- fix syntax errors in f-strings referencing module fields
- correct `retry_until_ready` iteration logic
- make retry timeout configurable via `RETRY_UNTIL_READY_SECONDS`
- add regression tests for `retry_until_ready`
- allow per-call configuration of retry timeout via `MODULES_HELLO_RETRY_SECONDS`, `MODULES_CHECK_RETRY_SECONDS`, and `MODULES_POST_RUN_RETRY_SECONDS`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848d041eb7c832b865d044ccaa0b06b