### PR TITLE
Support multiple documents per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ Each module must implement `hello`, `check`, `run`, and optionally
 `load`/`unload`. `hello` returns metadata (name, version, filterable and sortable
 attributes). `check` receives candidate documents and returns which ones to
 process. `run` performs the work and may store data in the provided metadata
-folder.
+folder. The value returned from `run` may be a single document or a list of
+documents. File metadata documents carry `doc_type="file"` while documents
+created by modules default to `doc_type="content"`.
 
 ## Development
 

--- a/packages/home_index/main.py
+++ b/packages/home_index/main.py
@@ -78,6 +78,7 @@ from meilisearch_python_sdk import AsyncClient
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 from multiprocessing import Manager
+from collections import defaultdict
 
 
 # endregion
@@ -308,6 +309,7 @@ async def init_meili():
         "size",
         "next",
         "type",
+        "doc_type",
     ] + list(chain(*[hello["filterable_attributes"] for hello in hellos]))
 
     try:
@@ -320,6 +322,7 @@ async def init_meili():
                 "size",
                 "next",
                 "type",
+                "doc_type",
             ]
             + list(chain(*[hello["sortable_attributes"] for hello in hellos]))
         )
@@ -511,7 +514,15 @@ def determine_hash(path, metadata_docs_by_hash, metadata_hashes_by_relpath):
     hash = None
     stat = path.stat()
     if relpath in metadata_hashes_by_relpath:
-        prev_hash = metadata_hashes_by_relpath[relpath]
+        prev_hashes = metadata_hashes_by_relpath[relpath]
+        prev_hash = next(
+            (
+                h
+                for h in prev_hashes
+                if metadata_docs_by_hash[h].get("doc_type", "file") == "file"
+            ),
+            next(iter(prev_hashes)),
+        )
         prev_mtime = metadata_docs_by_hash[prev_hash]["paths"][relpath]
         is_mtime_changed = truncate_mtime(stat.st_mtime) != prev_mtime
         if not is_mtime_changed:
@@ -551,9 +562,9 @@ def set_next_modules(files_docs_by_hash):
 
 def index_metadata():
     metadata_docs_by_hash = {}
-    metadata_hashes_by_relpath = {}
+    metadata_hashes_by_relpath = defaultdict(set)
     unmounted_archive_docs_by_hash = {}
-    unmounted_archive_hashes_by_relpath = {}
+    unmounted_archive_hashes_by_relpath = defaultdict(set)
 
     files_logger.info(f" * iterate metadata by-id")
     file_paths = [dir / "document.json" for dir in (BY_ID_DIRECTORY).iterdir()]
@@ -571,6 +582,8 @@ def index_metadata():
         hash = doc["id"]
         if hash in metadata_docs_by_hash:
             return
+        if "doc_type" not in doc:
+            doc["doc_type"] = "file"
         metadata_docs_by_hash[hash] = doc
 
         if all(
@@ -581,18 +594,13 @@ def index_metadata():
             doc_copy = copy.deepcopy(doc)
             unmounted_archive_docs_by_hash[hash] = doc_copy
 
-        unmounted_archive_hashes_by_relpath.update(
-            {
-                relpath: hash
-                for relpath in doc["paths"].keys()
-                if is_in_archive_dir(path_from_relpath(relpath))
+        for relpath in doc["paths"].keys():
+            if (
+                is_in_archive_dir(path_from_relpath(relpath))
                 and not path_from_relpath(relpath).exists()
-            }
-        )
-
-        metadata_hashes_by_relpath.update(
-            {relpath: hash for relpath in doc["paths"].keys()}
-        )
+            ):
+                unmounted_archive_hashes_by_relpath[relpath].add(hash)
+            metadata_hashes_by_relpath[relpath].add(hash)
 
     if file_paths:
         files_logger.info(f" * check {len(file_paths)} file hashes")
@@ -621,7 +629,7 @@ def index_files(
     unmounted_archive_hashes_by_relpath,
 ):
     files_docs_by_hash = unmounted_archive_docs_by_hash
-    files_hashes_by_relpath = unmounted_archive_hashes_by_relpath
+    files_hashes_by_relpath = copy.deepcopy(unmounted_archive_hashes_by_relpath)
 
     files_logger.info(f" * recursively walk files")
     file_paths = []
@@ -649,8 +657,12 @@ def index_files(
                 if is_in_archive_dir(path_from_relpath(relpath))
                 and not path_from_relpath(relpath).exists()
             }
+            if "doc_type" not in metadata_doc:
+                metadata_doc["doc_type"] = "file"
             doc = metadata_doc
         elif files_doc:
+            if "doc_type" not in files_doc:
+                files_doc["doc_type"] = "file"
             doc = files_doc
         else:
             doc = {
@@ -659,6 +671,7 @@ def index_files(
                 "mtime": truncate_mtime(stat.st_mtime),
                 "size": stat.st_size,
                 "type": mime_type,
+                "doc_type": "file",
             }
 
         doc["type"] = mime_type
@@ -667,7 +680,7 @@ def index_files(
         doc["mtime"] = max(doc["paths"].values())
 
         files_docs_by_hash[hash] = doc
-        files_hashes_by_relpath[relpath] = hash
+        files_hashes_by_relpath.setdefault(relpath, set()).add(hash)
 
     if file_paths:
         files_logger.info(f" * check {len(file_paths)} file hashes")
@@ -726,13 +739,14 @@ def update_metadata(
     )
 
     def handle_deleted_relpath(relpath):
-        metadata_doc = metadata_docs_by_hash[metadata_hashes_by_relpath[relpath]]
-        by_id_path = BY_ID_DIRECTORY / metadata_doc["id"]
+        for doc_id in metadata_hashes_by_relpath[relpath]:
+            metadata_doc = metadata_docs_by_hash[doc_id]
+            by_id_path = BY_ID_DIRECTORY / metadata_doc["id"]
+            if doc_id not in files_docs_by_hash and by_id_path.exists():
+                shutil.rmtree(by_id_path)
         by_path_path = BY_PATH_DIRECTORY / relpath
-        if not metadata_doc["id"] in files_docs_by_hash and by_id_path.exists():
-            shutil.rmtree(by_id_path)
-        if by_path_path.is_symlink():
-            by_path_path.unlink()
+        if by_path_path.exists():
+            shutil.rmtree(by_path_path)
         if (
             by_path_path.parent
             and by_path_path.parent != BY_PATH_DIRECTORY
@@ -747,11 +761,14 @@ def update_metadata(
         write_doc_json(doc)
         for relpath in doc["paths"].keys():
             by_path_path = BY_PATH_DIRECTORY / relpath
-            by_path_path.parent.mkdir(parents=True, exist_ok=True)
             if by_path_path.is_symlink():
                 by_path_path.unlink()
-            relative_target = os.path.relpath(by_id_path, by_path_path.parent)
-            by_path_path.symlink_to(relative_target, target_is_directory=True)
+            by_path_path.mkdir(parents=True, exist_ok=True)
+            link = by_path_path / doc["id"]
+            if link.is_symlink():
+                link.unlink()
+            relative_target = os.path.relpath(by_id_path, link.parent)
+            link.symlink_to(relative_target, target_is_directory=True)
 
     if deleted_relpaths:
         files_logger.info(f" * delete {len(deleted_relpaths)} metadata paths")
@@ -882,7 +899,19 @@ async def update_doc_from_module(document):
             next_module_name = module["name"]
             break
     document["next"] = next_module_name
+    if "doc_type" not in document:
+        document["doc_type"] = "content"
     write_doc_json(document)
+    for relpath in document["paths"].keys():
+        by_path_path = BY_PATH_DIRECTORY / relpath
+        if by_path_path.is_symlink():
+            by_path_path.unlink()
+        by_path_path.mkdir(parents=True, exist_ok=True)
+        link = by_path_path / document["id"]
+        if link.is_symlink():
+            link.unlink()
+        relative_target = os.path.relpath(BY_ID_DIRECTORY / document["id"], link.parent)
+        link.symlink_to(relative_target, target_is_directory=True)
     await add_or_update_document(document)
     return document
 
@@ -909,8 +938,10 @@ async def run_module(name, proxy):
                                 f"   * time up after {len(documents) - count} ({count} remain)"
                             )
                             return True
-                        document = json.loads(proxy.run(json.dumps(document)))
-                        await update_doc_from_module(document)
+                        result = json.loads(proxy.run(json.dumps(document)))
+                        docs = result if isinstance(result, list) else [result]
+                        for doc in docs:
+                            await update_doc_from_module(doc)
                     except Fault as e:
                         modules_logger.warning(f'   x "{relpath}": {str(e)}')
                     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ debugpy
 meilisearch-python-sdk
 python-magic
 xxhash
+requests

--- a/tests/test_doc_type.py
+++ b/tests/test_doc_type.py
@@ -1,0 +1,58 @@
+import importlib
+import types
+import sys
+import asyncio
+import os
+from collections import defaultdict
+
+import pytest
+
+
+def setup_main(tmp_path, monkeypatch):
+    sys.modules['magic'] = types.SimpleNamespace(Magic=lambda mime=True: types.SimpleNamespace(from_file=lambda path: 'text/plain'))
+    sys.modules['xxhash'] = types.SimpleNamespace(xxh64=lambda: types.SimpleNamespace(update=lambda x: None, hexdigest=lambda: 'hash'))
+    sys.modules['apscheduler.schedulers.background'] = types.SimpleNamespace(BackgroundScheduler=lambda *a, **k: types.SimpleNamespace(add_job=lambda *a, **k: None, start=lambda *a, **k: None))
+    sys.modules['apscheduler.triggers.cron'] = types.SimpleNamespace(CronTrigger=lambda **k: None)
+    sys.modules['apscheduler.triggers.interval'] = types.SimpleNamespace(IntervalTrigger=lambda **k: None)
+    sys.modules['meilisearch_python_sdk'] = types.SimpleNamespace(AsyncClient=lambda *a, **k: None)
+    monkeypatch.setenv("MODULES", "")
+    monkeypatch.setenv("INDEX_DIRECTORY", str(tmp_path / "index"))
+    monkeypatch.setenv("METADATA_DIRECTORY", str(tmp_path / "metadata"))
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(tmp_path / "metadata" / "by-id"))
+    monkeypatch.setenv("BY_PATH_DIRECTORY", str(tmp_path / "metadata" / "by-path"))
+    monkeypatch.setenv("ARCHIVE_DIRECTORY", str(tmp_path / "archive"))
+    monkeypatch.setenv("LOGGING_DIRECTORY", str(tmp_path / "logs"))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    
+    from pathlib import Path
+    repo_packages = Path(__file__).resolve().parents[1] / "packages"
+    sys.path.insert(0, str(repo_packages))
+    from home_index import main as hm
+    importlib.reload(hm)
+    return hm
+
+
+def test_index_files_sets_doc_type(tmp_path, monkeypatch):
+    hm = setup_main(tmp_path, monkeypatch)
+    from pathlib import Path
+    monkeypatch.setattr(Path, "walk", lambda self: ((Path(r), d, f) for r, d, f in os.walk(self)), raising=False)
+    hm.INDEX_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    file_path = hm.INDEX_DIRECTORY / "test.txt"
+    file_path.write_text("hi")
+
+    docs, _ = hm.index_files({}, defaultdict(set), {}, defaultdict(set))
+    assert list(docs.values())[0]["doc_type"] == "file"
+
+
+def test_update_doc_from_module_defaults_content(tmp_path, monkeypatch):
+    hm = setup_main(tmp_path, monkeypatch)
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(hm, "write_doc_json", lambda doc: None)
+    monkeypatch.setattr(hm, "add_or_update_document", noop)
+
+    doc = {"id": "1", "paths": {"a.txt": 0}, "next": "", "type": "text/plain"}
+    asyncio.run(hm.update_doc_from_module(doc))
+    assert doc["doc_type"] == "content"

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+import types
+import os
+from collections import defaultdict
+import asyncio
+
+
+def setup_main(tmp_path, monkeypatch):
+    sys.modules['magic'] = types.SimpleNamespace(Magic=lambda mime=True: types.SimpleNamespace(from_file=lambda path: 'text/plain'))
+    sys.modules['xxhash'] = types.SimpleNamespace(xxh64=lambda: types.SimpleNamespace(update=lambda x: None, hexdigest=lambda: 'hash'))
+    sys.modules['apscheduler.schedulers.background'] = types.SimpleNamespace(BackgroundScheduler=lambda *a, **k: types.SimpleNamespace(add_job=lambda *a, **k: None, start=lambda *a, **k: None))
+    sys.modules['apscheduler.triggers.cron'] = types.SimpleNamespace(CronTrigger=lambda **k: None)
+    sys.modules['apscheduler.triggers.interval'] = types.SimpleNamespace(IntervalTrigger=lambda **k: None)
+    sys.modules['meilisearch_python_sdk'] = types.SimpleNamespace(AsyncClient=lambda *a, **k: None)
+    monkeypatch.setenv("MODULES", "")
+    monkeypatch.setenv("INDEX_DIRECTORY", str(tmp_path / "index"))
+    monkeypatch.setenv("METADATA_DIRECTORY", str(tmp_path / "metadata"))
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(tmp_path / "metadata" / "by-id"))
+    monkeypatch.setenv("BY_PATH_DIRECTORY", str(tmp_path / "metadata" / "by-path"))
+    monkeypatch.setenv("ARCHIVE_DIRECTORY", str(tmp_path / "archive"))
+    monkeypatch.setenv("LOGGING_DIRECTORY", str(tmp_path / "logs"))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+
+    from pathlib import Path
+    repo_packages = Path(__file__).resolve().parents[1] / "packages"
+    sys.path.insert(0, str(repo_packages))
+    from home_index import main as hm
+    importlib.reload(hm)
+    return hm
+
+
+def test_deleted_file_removes_content_docs(tmp_path, monkeypatch):
+    hm = setup_main(tmp_path, monkeypatch)
+    from pathlib import Path
+    monkeypatch.setattr(Path, "walk", lambda self: ((Path(r), d, f) for r, d, f in os.walk(self)), raising=False)
+
+    file_doc = {"id": "f1", "paths": {"a.txt": 0}, "mtime": 0, "size": 1, "type": "text/plain", "next": "", "doc_type": "file"}
+    content_doc = {"id": "c1", "paths": {"a.txt": 0}, "mtime": 0, "size": 1, "type": "text/plain", "next": "", "doc_type": "content"}
+    hm.write_doc_json(file_doc)
+    hm.write_doc_json(content_doc)
+    by_path = hm.BY_PATH_DIRECTORY / "a.txt"
+    by_path.mkdir(parents=True, exist_ok=True)
+    for doc in (file_doc, content_doc):
+        link = by_path / doc["id"]
+        target = os.path.relpath(hm.BY_ID_DIRECTORY / doc["id"], link.parent)
+        link.symlink_to(target, target_is_directory=True)
+
+    (hm.INDEX_DIRECTORY).mkdir(parents=True, exist_ok=True)
+    md_docs, md_relpaths, ua_docs, ua_relpaths = hm.index_metadata()
+    files_docs, files_relpaths = hm.index_files(md_docs, md_relpaths, ua_docs, ua_relpaths)
+    hm.update_metadata(md_docs, md_relpaths, files_docs, files_relpaths)
+
+    assert not (hm.BY_ID_DIRECTORY / "f1").exists()
+    assert not (hm.BY_ID_DIRECTORY / "c1").exists()
+    assert not (hm.BY_PATH_DIRECTORY / "a.txt").exists()

--- a/tests/test_meili_integration.py
+++ b/tests/test_meili_integration.py
@@ -1,0 +1,277 @@
+import importlib
+import asyncio
+import os
+import sys
+import subprocess
+import time
+import uuid
+
+import json
+import pytest
+import types
+import requests
+from xmlrpc.server import SimpleXMLRPCServer
+from xmlrpc.client import ServerProxy
+import multiprocessing
+
+if "meilisearch_python_sdk" in sys.modules:
+    del sys.modules["meilisearch_python_sdk"]
+
+
+def start_meili(port, data_dir):
+    proc = subprocess.Popen([
+        "meilisearch",
+        "--http-addr",
+        f"127.0.0.1:{port}",
+        "--no-analytics",
+        "--db-path",
+        str(data_dir),
+    ])
+    for _ in range(30):
+        try:
+            r = requests.get(f"http://127.0.0.1:{port}/health")
+            if r.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(0.5)
+    return proc
+
+
+@pytest.fixture(scope="session")
+def meili_server(tmp_path_factory):
+    port = 7701
+    data_dir = tmp_path_factory.mktemp("meili_data")
+    proc = start_meili(port, data_dir)
+    yield f"http://127.0.0.1:{port}"
+    proc.terminate()
+    proc.wait()
+
+
+def run_dummy_module(port, name, suffix):
+    server = SimpleXMLRPCServer(("127.0.0.1", port), allow_none=True, logRequests=False)
+
+    def hello():
+        return json.dumps({"name": name, "version": 1, "filterable_attributes": [], "sortable_attributes": []})
+
+    def check(docs_json):
+        docs = json.loads(docs_json)
+        return json.dumps([d["id"] for d in docs])
+
+    def run(document_json):
+        doc = json.loads(document_json)
+        base = {"paths": doc["paths"], "mtime": doc["mtime"], "type": doc["type"], "next": ""}
+        return json.dumps([
+            doc,
+            {**base, "id": f"{doc['id']}_{suffix}a"},
+            {**base, "id": f"{doc['id']}_{suffix}b"},
+        ])
+
+    server.register_function(hello, "hello")
+    server.register_function(check, "check")
+    server.register_function(run, "run")
+    server.register_function(lambda: None, "load")
+    server.register_function(lambda: None, "unload")
+    server.serve_forever()
+
+
+@pytest.fixture(scope="session")
+def rpc_modules():
+    ports = [8801, 8802, 8803]
+    names = ["mod1", "mod2", "mod3"]
+    procs = []
+    hosts = []
+    for port, name in zip(ports, names):
+        p = multiprocessing.Process(target=run_dummy_module, args=(port, name, name))
+        p.start()
+        procs.append(p)
+        hosts.append(f"http://127.0.0.1:{port}")
+
+    for host in hosts:
+        proxy = ServerProxy(host)
+        for _ in range(30):
+            try:
+                proxy.hello()
+                break
+            except Exception:
+                time.sleep(0.1)
+    yield hosts
+    for p in procs:
+        p.terminate()
+        p.join()
+
+
+def setup_main(tmp_path, monkeypatch, host, index_name, modules=""):
+    monkeypatch.setenv("MODULES", modules)
+    if "meilisearch_python_sdk" in sys.modules:
+        del sys.modules["meilisearch_python_sdk"]
+    monkeypatch.setenv("MEILISEARCH_HOST", host)
+    monkeypatch.setenv("MEILISEARCH_INDEX_NAME", index_name)
+    monkeypatch.setenv("INDEX_DIRECTORY", str(tmp_path / "index"))
+    monkeypatch.setenv("MAX_HASH_WORKERS", "1")
+    sys.modules["magic"] = types.SimpleNamespace(Magic=lambda mime=True: types.SimpleNamespace(from_file=lambda path: "text/plain"))
+    counter = {"c": 0}
+    def new_xxh64():
+        class H:
+            def update(self, data):
+                pass
+
+            def hexdigest(self_inner):
+                counter["c"] += 1
+                return f"hash{counter['c']}"
+
+        return H()
+
+    sys.modules["xxhash"] = types.SimpleNamespace(xxh64=new_xxh64)
+    sys.modules["apscheduler.schedulers.background"] = types.SimpleNamespace(BackgroundScheduler=lambda *a, **k: types.SimpleNamespace(add_job=lambda *a, **k: None, start=lambda *a, **k: None))
+    sys.modules["apscheduler.triggers.cron"] = types.SimpleNamespace(CronTrigger=lambda **k: None)
+    sys.modules["apscheduler.triggers.interval"] = types.SimpleNamespace(IntervalTrigger=lambda **k: None)
+    monkeypatch.setenv("METADATA_DIRECTORY", str(tmp_path / "metadata"))
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(tmp_path / "metadata" / "by-id"))
+    monkeypatch.setenv("BY_PATH_DIRECTORY", str(tmp_path / "metadata" / "by-path"))
+    monkeypatch.setenv("ARCHIVE_DIRECTORY", str(tmp_path / "archive"))
+    monkeypatch.setenv("LOGGING_DIRECTORY", str(tmp_path / "logs"))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+
+    from pathlib import Path
+    monkeypatch.setattr(Path, "walk", lambda self: ((Path(r), d, f) for r, d, f in os.walk(self)), raising=False)
+
+    from pathlib import Path
+    repo_packages = Path(__file__).resolve().parents[1] / "packages"
+    sys.path.insert(0, str(repo_packages))
+    from home_index import main as hm
+    importlib.reload(hm)
+    return hm
+
+
+class DummyProxy:
+    def __init__(self, result):
+        self._result = result
+        self.loaded = False
+        self.unloaded = False
+
+    def load(self):
+        self.loaded = True
+
+    def run(self, document_json):
+        return json.dumps(self._result)
+
+    def unload(self):
+        self.unloaded = True
+
+    def check(self, docs):
+        return json.dumps([])
+
+
+def test_filter_by_doc_type(tmp_path, monkeypatch, meili_server):
+    import json
+
+    index_name = f"test_{uuid.uuid4().hex}"
+    hm = setup_main(tmp_path, monkeypatch, meili_server, index_name)
+
+    async def run():
+        await hm.init_meili()
+        file_doc = {
+            "id": "f1",
+            "paths": {"a.txt": 0},
+            "mtime": 0,
+            "size": 1,
+            "type": "text/plain",
+            "next": "",
+            "doc_type": "file",
+        }
+        content_doc = {
+            "id": "c1",
+            "paths": {"a.txt": 0},
+            "mtime": 0,
+            "size": 1,
+            "type": "text/plain",
+            "next": "",
+            "doc_type": "content",
+        }
+        await hm.add_or_update_document(file_doc)
+        await hm.add_or_update_document(content_doc)
+        await hm.wait_for_meili_idle()
+        files = await hm.index.get_documents(filter="doc_type = file")
+        assert [d["id"] for d in files.results] == ["f1"]
+        contents = await hm.index.get_documents(filter="doc_type = content")
+        assert [d["id"] for d in contents.results] == ["c1"]
+
+    asyncio.run(run())
+
+
+def test_run_module_multiple_docs(tmp_path, monkeypatch, meili_server):
+    import json
+
+    index_name = f"test_{uuid.uuid4().hex}"
+    hm = setup_main(tmp_path, monkeypatch, meili_server, index_name)
+
+    async def run():
+        await hm.init_meili()
+        file_doc = {
+            "id": "f1",
+            "paths": {"a.txt": 0},
+            "mtime": 0,
+            "size": 1,
+            "type": "text/plain",
+            "next": "test",
+            "doc_type": "file",
+        }
+        await hm.add_or_update_document(file_doc)
+        await hm.wait_for_meili_idle()
+
+        proxy = DummyProxy([
+            {
+                "id": "c1",
+                "paths": {"a.txt": 0},
+                "mtime": 1,
+                "type": "text/plain",
+                "next": "",
+            },
+            {
+                "id": "c2",
+                "paths": {"a.txt": 0},
+                "mtime": 1,
+                "type": "text/plain",
+                "next": "",
+            },
+        ])
+
+        async def pending(name):
+            return [file_doc]
+
+        monkeypatch.setattr(hm, "get_all_pending_jobs", pending)
+
+        await hm.run_module("test", proxy)
+        await hm.wait_for_meili_idle()
+
+        docs = await hm.index.get_documents(limit=10)
+        ids = {d["id"] for d in docs.results}
+        assert {"f1", "c1", "c2"} <= ids
+        assert proxy.loaded and proxy.unloaded
+
+    asyncio.run(run())
+
+
+def test_three_rpc_modules(tmp_path, monkeypatch, meili_server, rpc_modules):
+    index_name = f"test_{uuid.uuid4().hex}"
+    hm = setup_main(tmp_path, monkeypatch, meili_server, index_name, modules=",".join(rpc_modules))
+
+    async def run():
+        for i in range(5):
+            path = hm.INDEX_DIRECTORY / f"file{i}.txt"
+            path.write_text(str(i))
+
+        await hm.init_meili()
+        await hm.sync_documents()
+
+        for module in hm.module_values:
+            await hm.run_module(module["name"], module["proxy"])
+
+        await hm.wait_for_meili_idle()
+        files = await hm.index.get_documents(filter="doc_type = file", limit=20)
+        contents = await hm.index.get_documents(filter="doc_type = content", limit=100)
+        assert len(files.results) == 5
+        assert len(contents.results) == 30
+
+    asyncio.run(run())

--- a/tests/test_run_module.py
+++ b/tests/test_run_module.py
@@ -1,0 +1,104 @@
+import types
+import sys
+import asyncio
+import json
+from collections import defaultdict
+
+import pytest
+
+
+def setup_main(tmp_path, monkeypatch):
+    sys.modules['magic'] = types.SimpleNamespace(Magic=lambda mime=True: types.SimpleNamespace(from_file=lambda path: 'text/plain'))
+    sys.modules['xxhash'] = types.SimpleNamespace(xxh64=lambda: types.SimpleNamespace(update=lambda x: None, hexdigest=lambda: 'hash'))
+    sys.modules['apscheduler.schedulers.background'] = types.SimpleNamespace(BackgroundScheduler=lambda *a, **k: types.SimpleNamespace(add_job=lambda *a, **k: None, start=lambda *a, **k: None))
+    sys.modules['apscheduler.triggers.cron'] = types.SimpleNamespace(CronTrigger=lambda **k: None)
+    sys.modules['apscheduler.triggers.interval'] = types.SimpleNamespace(IntervalTrigger=lambda **k: None)
+    sys.modules['meilisearch_python_sdk'] = types.SimpleNamespace(AsyncClient=lambda *a, **k: None)
+    monkeypatch.setenv("MODULES", "")
+    monkeypatch.setenv("INDEX_DIRECTORY", str(tmp_path / "index"))
+    monkeypatch.setenv("METADATA_DIRECTORY", str(tmp_path / "metadata"))
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(tmp_path / "metadata" / "by-id"))
+    monkeypatch.setenv("BY_PATH_DIRECTORY", str(tmp_path / "metadata" / "by-path"))
+    monkeypatch.setenv("ARCHIVE_DIRECTORY", str(tmp_path / "archive"))
+    monkeypatch.setenv("LOGGING_DIRECTORY", str(tmp_path / "logs"))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+
+    from pathlib import Path
+    repo_packages = Path(__file__).resolve().parents[1] / "packages"
+    sys.path.insert(0, str(repo_packages))
+    from home_index import main as hm
+    import importlib
+    importlib.reload(hm)
+    return hm
+
+
+class DummyProxy:
+    def __init__(self, result):
+        self._result = result
+        self.loaded = False
+        self.unloaded = False
+
+    def load(self):
+        self.loaded = True
+
+    def run(self, document_json):
+        return json.dumps(self._result)
+
+    def unload(self):
+        self.unloaded = True
+
+    def check(self, docs):
+        return json.dumps([])
+
+
+def test_run_module_handles_single_document(tmp_path, monkeypatch):
+    hm = setup_main(tmp_path, monkeypatch)
+
+    processed = []
+
+    async def update(doc):
+        processed.append(doc)
+
+    async def pending(name):
+        return [{"id": "1", "paths": {"a.txt": 0}, "mtime": 0, "type": "text/plain", "next": ""}]
+
+    async def wait():
+        return None
+
+    monkeypatch.setattr(hm, "get_all_pending_jobs", pending)
+    monkeypatch.setattr(hm, "update_doc_from_module", update)
+    monkeypatch.setattr(hm, "wait_for_meili_idle", wait)
+
+    proxy = DummyProxy({"id": "1", "paths": {"a.txt": 0}, "mtime": 0, "type": "text/plain", "next": ""})
+    asyncio.run(hm.run_module("test", proxy))
+
+    assert proxy.loaded and proxy.unloaded
+    assert len(processed) == 1
+
+
+def test_run_module_handles_multiple_documents(tmp_path, monkeypatch):
+    hm = setup_main(tmp_path, monkeypatch)
+
+    processed = []
+
+    async def update(doc):
+        processed.append(doc)
+
+    async def pending(name):
+        return [{"id": "1", "paths": {"a.txt": 0}, "mtime": 0, "type": "text/plain", "next": ""}]
+
+    async def wait():
+        return None
+
+    monkeypatch.setattr(hm, "get_all_pending_jobs", pending)
+    monkeypatch.setattr(hm, "update_doc_from_module", update)
+    monkeypatch.setattr(hm, "wait_for_meili_idle", wait)
+
+    proxy = DummyProxy([
+        {"id": "1a", "paths": {"a.txt": 0}, "mtime": 0, "type": "text/plain", "next": ""},
+        {"id": "1b", "paths": {"a.txt": 0}, "mtime": 0, "type": "text/plain", "next": ""},
+    ])
+    asyncio.run(hm.run_module("test", proxy))
+
+    assert proxy.loaded and proxy.unloaded
+    assert len(processed) == 2


### PR DESCRIPTION
## Summary
- allow modules to return multiple documents
- store multiple doc links under `by-path`
- add `doc_type` field to distinguish file documents from content
- update Meilisearch filterable/sortable attributes
- tests for `doc_type` and multi-document returns
- ensure content docs are removed when file is deleted
- add integration tests with real Meilisearch server
- test multiple RPC modules with many files
- add requests dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68499968fc34832bae99ec6ee7629432