### PR TITLE
Add Meilisearch document schema

### DIFF
--- a/docs/meilisearch_document.schema.json
+++ b/docs/meilisearch_document.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Home Index File Document",
+  "description": "Schema describing documents stored in the Meilisearch \"files\" index.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "xxh64 hexadecimal digest uniquely identifying the file contents"
+    },
+    "type": {
+      "type": "string",
+      "description": "MIME type of the file"
+    },
+    "size": {
+      "type": "integer",
+      "description": "File size in bytes"
+    },
+    "paths": {
+      "type": "object",
+      "description": "Mapping of relative file paths to their modification times (seconds since Unix epoch, truncated to 4 decimal places)",
+      "additionalProperties": {
+        "type": "number",
+        "description": "Modification time in epoch seconds"
+      }
+    },
+    "copies": {
+      "type": "integer",
+      "description": "Number of entries in the \"paths\" map"
+    },
+    "mtime": {
+      "type": "number",
+      "description": "Most recent modification time across all copies (epoch seconds truncated to 4 decimals)"
+    },
+    "next": {
+      "type": "string",
+      "description": "Name of the next module to process this document or empty string when none",
+      "default": ""
+    }
+  },
+  "required": ["id", "type", "size", "paths", "copies", "mtime"],
+  "additionalProperties": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ apscheduler
 debugpy
 meilisearch-python-sdk
 python-magic
+jsonschema
 xxhash

--- a/tests/test_meilisearch_schema.py
+++ b/tests/test_meilisearch_schema.py
@@ -1,0 +1,12 @@
+import json
+import pathlib
+
+from jsonschema import Draft7Validator
+
+SCHEMA_PATH = pathlib.Path('docs/meilisearch_document.schema.json')
+
+
+def test_schema_is_valid():
+    schema = json.loads(SCHEMA_PATH.read_text())
+    # raises jsonschema.exceptions.SchemaError if invalid
+    Draft7Validator.check_schema(schema)


### PR DESCRIPTION
## Summary
- document the file documents stored in Meilisearch
- clarify each property in the schema
- add jsonschema unit test for schema validity

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b6822d2e0832bbb67c0f29799fb57