### PR TITLE
Enable vector indexing of chunks

### DIFF
--- a/docs/meilisearch_file_chunk.schema.json
+++ b/docs/meilisearch_file_chunk.schema.json
@@ -12,15 +12,24 @@
       "type": "string",
       "description": "ID of the parent file document"
     },
+    "name": {
+      "type": "string",
+      "description": "Chunk name used for the 'passage:' prefix"
+    },
     "text": {
       "type": "string",
-      "description": "Chunk text content"
+      "description": "Chunk text content prefixed with 'passage: <name>'"
     },
     "metadata": {
       "type": "object",
       "description": "Additional metadata provided by modules"
+    },
+    "_vector": {
+      "type": "array",
+      "items": {"type": "number"},
+      "description": "Sentence embedding vector for semantic search"
     }
   },
-  "required": ["id", "file_id", "text"],
+  "required": ["id", "file_id", "name", "text"],
   "additionalProperties": true
 }

--- a/packages/home_index/main.py
+++ b/packages/home_index/main.py
@@ -115,6 +115,16 @@ CPU_COUNT = os.cpu_count()
 MAX_HASH_WORKERS = int(os.environ.get("MAX_HASH_WORKERS", CPU_COUNT / 2))
 MAX_FILE_WORKERS = int(os.environ.get("MAX_FILE_WORKERS", CPU_COUNT / 2))
 
+# embedding configuration
+EMBED_MODEL_NAME = os.environ.get("EMBED_MODEL_NAME", "intfloat/e5-small-v2")
+try:
+    import torch
+    default_device = "cuda" if torch.cuda.is_available() else "cpu"
+except Exception:
+    default_device = "cpu"
+EMBED_DEVICE = os.environ.get("EMBED_DEVICE", default_device)
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "384"))
+
 INDEX_DIRECTORY = Path(os.environ.get("INDEX_DIRECTORY", "/files"))
 INDEX_DIRECTORY.mkdir(parents=True, exist_ok=True)
 
@@ -153,6 +163,26 @@ CHECK_RETRY_SECONDS = int(
 POST_RUN_RETRY_SECONDS = int(
     os.environ.get("MODULES_POST_RUN_RETRY_SECONDS", RETRY_UNTIL_READY_SECONDS)
 )
+
+
+# embedding model setup
+embedding_model = None
+
+
+def init_embedder():
+    """Initialize the sentence transformer model on first use."""
+    global embedding_model
+    if embedding_model is None:
+        from sentence_transformers import SentenceTransformer
+        embedding_model = SentenceTransformer(EMBED_MODEL_NAME, device=EMBED_DEVICE)
+
+
+def embed_texts(texts):
+    """Return embeddings for a list of texts."""
+    if embedding_model is None:
+        init_embedder()
+    vectors = embedding_model.encode(texts, convert_to_numpy=True)
+    return [vec.tolist() for vec in vectors]
 
 
 def retry_until_ready(fn, msg, seconds=RETRY_UNTIL_READY_SECONDS):
@@ -326,6 +356,16 @@ async def init_meili():
         else:
             logging.exception(f"meili chunk init failed")
             raise
+
+    try:
+        await chunk_index.update_settings(
+            {
+                "vector": {"size": EMBED_DIM, "distance": "Cosine"},
+                "filterableAttributes": ["file_id"],
+            }
+        )
+    except Exception:
+        logging.exception("meili update chunk vector settings failed")
 
     filterable_attributes = [
         "mtime",
@@ -996,6 +1036,15 @@ async def run_module(name, proxy):
                             delete_chunk_ids = []
 
                         if chunk_docs:
+                            texts = []
+                            for chunk in chunk_docs:
+                                if "text" in chunk:
+                                    prefix = chunk["name"]
+                                    chunk["text"] = f"passage: {prefix}\n" + chunk["text"]
+                                    texts.append(chunk["text"])
+                            vectors = embed_texts(texts)
+                            for chunk, vec in zip(chunk_docs, vectors):
+                                chunk["_vector"] = vec
                             await add_or_update_chunk_documents(chunk_docs)
                         if delete_chunk_ids:
                             await delete_chunk_docs_by_id(delete_chunk_ids)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ meilisearch-python-sdk
 python-magic
 jsonschema
 xxhash
+sentence-transformers

--- a/tests/test_chunk_integration.py
+++ b/tests/test_chunk_integration.py
@@ -58,7 +58,13 @@ def dummy_module_server(port):
 
     def run(document_json):
         doc = json.loads(document_json)
-        chunk = {"id": "chunk1", "file_id": doc["id"], "text": "hello", "metadata": {}}
+        chunk = {
+            "id": "chunk1",
+            "file_id": doc["id"],
+            "name": "MyChunk",
+            "text": "hello",
+            "metadata": {},
+        }
         return json.dumps({"document": doc, "chunk_docs": [chunk]})
 
     def unload():
@@ -134,11 +140,13 @@ def test_run_module_adds_and_deletes_chunks(tmp_path):
             importlib.reload(hi)
             await hi.init_meili()
 
+            hi.embed_texts = lambda texts: [[0.0] * hi.EMBED_DIM for _ in texts]
+
             doc = {
                 "id": "file1",
                 "type": "text/plain",
                 "size": 1,
-                "paths": {"a.txt": 1.0},
+                "paths": {"foo/a.txt": 1.0},
                 "copies": 1,
                 "mtime": 1.0,
                 "next": "dummy",
@@ -153,6 +161,8 @@ def test_run_module_adds_and_deletes_chunks(tmp_path):
 
             chunk = await hi.chunk_index.get_document("chunk1")
             assert chunk["file_id"] == "file1"
+            assert chunk["text"].startswith("passage: MyChunk\n")
+            assert len(chunk["_vector"]) == hi.EMBED_DIM
 
             await hi.delete_docs_by_id(["file1"])
             await hi.delete_chunk_docs_by_file_ids(["file1"])


### PR DESCRIPTION
## Summary
- add `name` field to chunk schema
- prefix chunk text with the chunk's name when storing
- adjust integration test dummy module and expectations
- load sentence-transformers lazily and update chunk index vector settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8d7f3fac832b8e09d999f8a7fc31