### PR TITLE
Fix Python version requirement and improve compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Home Index is a file indexing service built around [Meilisearch](https://www.meilisearch.com/). It scans a directory of files, stores metadata under a configurable location and can enrich that metadata by calling external **modules**. Modules handle tasks such as transcription, OCR, scraping, thumbnails or caption generation so your files become easily searchable.
 
+This project requires **Python 3.8 or higher** when running outside the provided Docker environment.
+
 ## Quick start
 
 The repository includes a `docker-compose.yml` that starts Home Index, Meilisearch and a sample module. After installing Docker, run:

--- a/packages/home_index/main.py
+++ b/packages/home_index/main.py
@@ -740,11 +740,12 @@ def index_files(
 
     files_logger.info(f" * recursively walk files")
     file_paths = []
-    for root, _, files in INDEX_DIRECTORY.walk():
-        if any(dir in root.parents for dir in RESERVED_FILES_DIRS):
+    for root, _, files in os.walk(INDEX_DIRECTORY):
+        root_path = Path(root)
+        if any(dir in root_path.parents for dir in RESERVED_FILES_DIRS):
             continue
         for f in files:
-            file_paths.append(root / f)
+            file_paths.append(root_path / f)
 
     def handle_hash_at_path(args):
         path, hash, stat, mime_type = args

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(
     url="https://github.com/nashspence/home-index",
     packages=find_packages(where="packages"),
     package_dir={"": "packages"},
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- document Python version requirement in README
- add `python_requires` to setup configuration
- switch from `Path.walk` to `os.walk` for broader Python compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d4bdaee64832b830a07fb244a0b93