### PR TITLE
Prevent traversal into reserved directories

### DIFF
--- a/packages/home_index/main.py
+++ b/packages/home_index/main.py
@@ -745,7 +745,7 @@ def index_files(
     file_paths = []
     for root, _, files in os.walk(INDEX_DIRECTORY):
         root_path = Path(root)
-        if any(dir in root_path.parents for dir in RESERVED_FILES_DIRS):
+        if any(root_path == dir or dir in root_path.parents for dir in RESERVED_FILES_DIRS):
             continue
         for f in files:
             file_paths.append(root_path / f)


### PR DESCRIPTION
## Summary
- avoid scanning reserved directories in `index_files`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbc81a168832bad0fb13b1f3ecc4e