### PR TITLE
Adjust chunk schema and module integration

### DIFF
--- a/docs/meilisearch_file_chunk.schema.json
+++ b/docs/meilisearch_file_chunk.schema.json
@@ -12,17 +12,21 @@
       "type": "string",
       "description": "ID of the parent file document"
     },
-    "name": {
-      "type": "string",
-      "description": "Chunk name used for the 'passage:' prefix"
-    },
     "text": {
       "type": "string",
-      "description": "Chunk text content prefixed with 'passage: <name>'"
+      "description": "Chunk text content"
     },
-    "metadata": {
-      "type": "object",
-      "description": "Additional metadata provided by modules"
+    "module": {
+      "type": "string",
+      "description": "Name of the module that produced the chunk"
+    },
+    "start": {
+      "type": "integer",
+      "description": "Optional start offset of the chunk in the source"
+    },
+    "end": {
+      "type": "integer",
+      "description": "Optional end offset of the chunk in the source"
     },
     "_vector": {
       "type": "array",
@@ -30,6 +34,6 @@
       "description": "Sentence embedding vector for semantic search"
     }
   },
-  "required": ["id", "file_id", "name", "text"],
+  "required": ["id", "file_id", "module", "text"],
   "additionalProperties": true
 }

--- a/packages/home_index/main.py
+++ b/packages/home_index/main.py
@@ -1043,9 +1043,9 @@ async def run_module(name, proxy):
                             texts = []
                             for chunk in chunk_docs:
                                 if "text" in chunk:
-                                    prefix = chunk["name"]
-                                    chunk["text"] = f"passage: {prefix}\n" + chunk["text"]
+                                    chunk["text"] = "passage: " + chunk["text"]
                                     texts.append(chunk["text"])
+                                chunk.setdefault("module", name)
                             vectors = embed_texts(texts)
                             for chunk, vec in zip(chunk_docs, vectors):
                                 chunk["_vector"] = vec

--- a/tests/test_chunk_integration.py
+++ b/tests/test_chunk_integration.py
@@ -61,9 +61,8 @@ def dummy_module_server(port):
         chunk = {
             "id": "chunk1",
             "file_id": doc["id"],
-            "name": "MyChunk",
+            "module": "dummy",
             "text": "hello",
-            "metadata": {},
         }
         return json.dumps({"document": doc, "chunk_docs": [chunk]})
 
@@ -161,7 +160,8 @@ def test_run_module_adds_and_deletes_chunks(tmp_path):
 
             chunk = await hi.chunk_index.get_document("chunk1")
             assert chunk["file_id"] == "file1"
-            assert chunk["text"].startswith("passage: MyChunk\n")
+            assert chunk["module"] == "dummy"
+            assert chunk["text"] == "passage: hello"
             assert len(chunk["_vector"]) == hi.EMBED_DIM
 
             await hi.delete_docs_by_id(["file1"])

--- a/tests/test_large_indexing.py
+++ b/tests/test_large_indexing.py
@@ -63,9 +63,8 @@ def dummy_module_server(name, port, add_chunk=False):
             chunk = {
                 "id": f"{doc['id']}_chunk",
                 "file_id": doc["id"],
-                "name": f"{name}Chunk",
+                "module": name,
                 "text": "hello",
-                "metadata": {},
             }
             return json.dumps({"document": doc, "chunk_docs": [chunk]})
         return json.dumps(doc)


### PR DESCRIPTION
## Summary
- add `module`, `start`, and `end` properties to chunk schema and remove `name` and `metadata`
- strip prefix logic from chunk embedding
- update tests to the new chunk format
- prefix `passage:` on chunk texts when running modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f64916124832bb401602eb5140f32