### PR TITLE
Update schema to use float offsets

### DIFF
--- a/docs/meilisearch_file_chunk.schema.json
+++ b/docs/meilisearch_file_chunk.schema.json
@@ -21,12 +21,12 @@
       "description": "Name of the module that produced the chunk"
     },
     "start": {
-      "type": "integer",
-      "description": "Optional start offset of the chunk in the source"
+      "type": "number",
+      "description": "Optional start offset of the chunk in the source (float)"
     },
     "end": {
-      "type": "integer",
-      "description": "Optional end offset of the chunk in the source"
+      "type": "number",
+      "description": "Optional end offset of the chunk in the source (float)"
     },
     "_vector": {
       "type": "array",


### PR DESCRIPTION
## Summary
- use numeric values for start and end offsets in file chunk schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6e445404832b953a3e245159b796