### PR TITLE
Improve chunk utilities and dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ jsonschema
 xxhash
 sentence-transformers
 httpx
+
+langchain-core
+langchain-text-splitters
+transformers


### PR DESCRIPTION
## Summary
- enhance `segments_to_chunk_docs` with configurable metadata support
- preserve arbitrary fields when splitting chunk docs
- install and run tests using pytest

## Testing
- `pip install -r requirements.txt` *(fails: operation canceled)*
- `pip install pytest`
- `python -m pytest -q` *(fails: ModuleNotFoundError: meilisearch_python_sdk)*

------
https://chatgpt.com/codex/tasks/task_e_684fb41fc154832bb76c68b2b6d2529b