### PR TITLE
Add Docker compose test workflow

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,38 @@
+name: Docker Compose Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Build containers
+        run: docker compose build
+      - name: Start services
+        run: docker compose up -d
+      - name: Wait for Meilisearch
+        run: |
+          for i in {1..30}; do
+            if curl -fs http://localhost:7700/health > /dev/null; then
+              break
+            fi
+            sleep 2
+          done
+      - name: Run tests
+        env:
+          EXTERNAL_MEILISEARCH: '1'
+          MEILISEARCH_HOST: 'http://localhost:7700'
+        run: pytest -q
+      - name: Stop services
+        run: docker compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.11-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.9'
 services:
   home-index:
     build:

--- a/docs/sample_chunk_document.json
+++ b/docs/sample_chunk_document.json
@@ -1,0 +1,6 @@
+{
+  "id": "example_chunk",
+  "file_id": "example-file",
+  "module": "pretend",
+  "text": "sample text"
+}

--- a/docs/sample_document.json
+++ b/docs/sample_document.json
@@ -1,0 +1,9 @@
+{
+  "id": "example-file",
+  "type": "text/plain",
+  "size": 5,
+  "paths": {"file.txt": 1700000000},
+  "copies": 1,
+  "mtime": 1700000000,
+  "next": ""
+}

--- a/examples/module_template/Dockerfile
+++ b/examples/module_template/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.11-alpine
 ENV PYTHONUNBUFFERED=1
 RUN apk add --no-cache \
     attr \

--- a/tests/fake_module.py
+++ b/tests/fake_module.py
@@ -1,0 +1,43 @@
+state = {"loaded": False, "unloaded": False}
+
+NAME = "pretend"
+VERSION = 1
+
+
+def hello():
+    return {
+        "name": NAME,
+        "version": VERSION,
+        "filterable_attributes": [],
+        "sortable_attributes": [],
+    }
+
+
+def check(file_path, document, metadata_dir_path):
+    return True
+
+
+def run(file_path, document, metadata_dir_path):
+    chunk = {
+        "id": "example_chunk",
+        "file_id": document["id"],
+        "module": NAME,
+        "text": "sample text",
+    }
+    return {"document": document, "chunk_docs": [chunk]}
+
+
+def load():
+    state["loaded"] = True
+
+
+def unload():
+    state["unloaded"] = True
+
+
+def start(port):
+    import os
+    os.environ["PORT"] = str(port)
+    import importlib
+    rs = importlib.import_module('home_index_module.run_server')
+    rs.run_server(NAME, hello, check, run, load_fn=load, unload_fn=unload)

--- a/tests/test_chunk_integration.py
+++ b/tests/test_chunk_integration.py
@@ -16,6 +16,20 @@ import pytest
 
 @contextmanager
 def meilisearch_server(tmp_path, port):
+    if os.environ.get("EXTERNAL_MEILISEARCH"):
+        # Wait for the external service to be ready
+        host = os.environ.get("MEILISEARCH_HOST", f"http://127.0.0.1:{port}")
+        for _ in range(30):
+            try:
+                if httpx.get(f"{host}/health").status_code == 200:
+                    break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise RuntimeError("Meilisearch failed to start")
+        yield
+        return
+
     proc = subprocess.Popen(
         ["meilisearch", "--db-path", str(tmp_path), "--http-addr", f"127.0.0.1:{port}"],
         stdout=subprocess.DEVNULL,
@@ -126,8 +140,9 @@ def dummy_module_server_plain(port):
 def test_run_module_adds_and_deletes_chunks(tmp_path):
     async def run():
         meili_port = 7710
+        host = os.environ.get("MEILISEARCH_HOST", f"http://127.0.0.1:{meili_port}")
         with meilisearch_server(tmp_path / "meili", meili_port):
-            os.environ["MEILISEARCH_HOST"] = f"http://127.0.0.1:{meili_port}"
+            os.environ["MEILISEARCH_HOST"] = host
             os.environ["MEILISEARCH_INDEX_NAME"] = "files_test"
             os.environ["MEILISEARCH_CHUNK_INDEX_NAME"] = "chunks_test"
             os.environ["MODULES"] = ""
@@ -177,8 +192,9 @@ def test_run_module_adds_and_deletes_chunks(tmp_path):
 def test_run_module_handles_document_return(tmp_path):
     async def run():
         meili_port = 7711
+        host = os.environ.get("MEILISEARCH_HOST", f"http://127.0.0.1:{meili_port}")
         with meilisearch_server(tmp_path / "meili", meili_port):
-            os.environ["MEILISEARCH_HOST"] = f"http://127.0.0.1:{meili_port}"
+            os.environ["MEILISEARCH_HOST"] = host
             os.environ["MEILISEARCH_INDEX_NAME"] = "files_test2"
             os.environ["MEILISEARCH_CHUNK_INDEX_NAME"] = "chunks_test2"
             os.environ["MODULES"] = ""

--- a/tests/test_large_indexing.py
+++ b/tests/test_large_indexing.py
@@ -17,6 +17,19 @@ import xxhash
 
 @contextmanager
 def meilisearch_server(tmp_path, port):
+    if os.environ.get("EXTERNAL_MEILISEARCH"):
+        host = os.environ.get("MEILISEARCH_HOST", f"http://127.0.0.1:{port}")
+        for _ in range(30):
+            try:
+                if httpx.get(f"{host}/health").status_code == 200:
+                    break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise RuntimeError("Meilisearch failed to start")
+        yield
+        return
+
     proc = subprocess.Popen(
         ["meilisearch", "--db-path", str(tmp_path), "--http-addr", f"127.0.0.1:{port}"],
         stdout=subprocess.DEVNULL,
@@ -108,8 +121,9 @@ def test_sync_and_run_many_files(tmp_path):
         os.environ["ARCHIVE_DIRECTORY"] = str(archive)
         os.environ["LOGGING_DIRECTORY"] = str(log_dir)
         meili_port = 7720
+        host = os.environ.get("MEILISEARCH_HOST", f"http://127.0.0.1:{meili_port}")
         with meilisearch_server(tmp_path / "meili", meili_port):
-            os.environ["MEILISEARCH_HOST"] = f"http://127.0.0.1:{meili_port}"
+            os.environ["MEILISEARCH_HOST"] = host
             os.environ["MEILISEARCH_INDEX_NAME"] = "files_many"
             os.environ["MEILISEARCH_CHUNK_INDEX_NAME"] = "chunks_many"
             with dummy_module_server("mod1", 9020, add_chunk=True) as p1, dummy_module_server("mod2", 9021) as p2:

--- a/tests/test_run_server_module.py
+++ b/tests/test_run_server_module.py
@@ -1,0 +1,57 @@
+import json
+import os
+import time
+import multiprocessing
+from xmlrpc.client import ServerProxy
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packages"))
+import fake_module
+
+
+def start_server(port):
+    fake_module.start(port)
+
+
+def wait_for_server(port, timeout=5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            ServerProxy(f"http://127.0.0.1:{port}").hello()
+            return
+        except Exception:
+            time.sleep(0.1)
+    raise RuntimeError("server did not start")
+
+
+def test_run_server_basic(tmp_path):
+    port = 9050
+    proc = multiprocessing.Process(target=start_server, args=(port,), daemon=True)
+    proc.start()
+    try:
+        wait_for_server(port)
+        proxy = ServerProxy(f"http://127.0.0.1:{port}")
+
+        proxy.load()
+
+        hello = json.loads(proxy.hello())
+        assert hello["name"] == fake_module.NAME
+        assert hello["version"] == fake_module.VERSION
+
+        docs = json.dumps([json.loads(open('docs/sample_document.json').read())])
+        checked = json.loads(proxy.check(docs))
+        assert checked == ["example-file"]
+
+        doc = json.loads(open('docs/sample_document.json').read())
+        result = json.loads(proxy.run(json.dumps(doc)))
+        assert result["document"]["id"] == doc["id"]
+        assert result["chunk_docs"][0]["module"] == fake_module.NAME
+
+        proxy.unload()
+    finally:
+        proc.terminate()
+        proc.join()


### PR DESCRIPTION
## Summary
- add workflow running docker-compose for integration tests
- modernize Dockerfiles and docker-compose version
- create sample JSON documents for tests
- add fake module and tests for run_server
- run all tests via docker workflow

## Testing
- `pytest -q tests/test_retry.py tests/test_meilisearch_schema.py tests/test_meilisearch_file_chunk_schema.py tests/test_run_server_module.py`


------
https://chatgpt.com/codex/tasks/task_e_684fcbdcbb70832bbc63924f8697199b