### PR TITLE
Apply maintenance pins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
       EXTERNAL_MEILISEARCH: '1'
       MEILISEARCH_HOST: 'http://localhost:7700'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.6.0
         with:
           python-version: '3.11'
       - name: Install deps

--- a/examples/module_template/requirements.txt
+++ b/examples/module_template/requirements.txt
@@ -1,1 +1,4 @@
-git+https://github.com/nashspence/home-index.git
+# Pin the version of home-index used for the module template to the
+# commit currently checked out in this repository. This avoids pulling
+# arbitrary changes when building example modules.
+git+https://github.com/nashspence/home-index.git@1e5a67cb90465abf1c8e0885c7614c9e28314660


### PR DESCRIPTION
## Summary
- pin `home-index` requirement in module template
- pin CI workflows to latest action releases

## Testing
- `bash agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685232a7551c832b979933683e5cb65c