### PR TITLE
Maintenance: typed scheduler for F1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ your files using a locally run language model backed by Meilisearch.
 ## License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Planned Maintenance
+
+- `check.sh` only runs Black and Ruff; it should also run type checking and unit tests.
+- Features F2–F12 lack accompanying documentation files under `docs/`.

--- a/features/F1/scheduler.py
+++ b/features/F1/scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Callable, Dict
+from typing import Callable
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -10,26 +10,20 @@ from apscheduler.triggers.cron import CronTrigger
 
 def parse_cron_env(
     env_var: str = "CRON_EXPRESSION", default: str = "0 3 * * *"
-) -> Dict[str, str]:
-    """Return CronTrigger kwargs from the CRON_EXPRESSION environment variable."""
+) -> CronTrigger:
+    """Return a ``CronTrigger`` built from the given environment variable."""
     cron_expression = os.getenv(env_var, default)
-    parts = cron_expression.split()
-    if len(parts) != 5:
+    try:
+        return CronTrigger.from_crontab(cron_expression)
+    except ValueError as exc:  # pragma: no cover - defensive
         raise ValueError(
-            f"Invalid cron expression in {env_var}: '{cron_expression}'. Must have 5 fields."
-        )
-    return {
-        "minute": parts[0],
-        "hour": parts[1],
-        "day": parts[2],
-        "month": parts[3],
-        "day_of_week": parts[4],
-    }
+            f"Invalid cron expression in {env_var}: '{cron_expression}'."
+        ) from exc
 
 
 def attach_sync_job(
     scheduler: BackgroundScheduler, debug: bool, run_fn: Callable[[], None]
 ) -> None:
     """Attach the periodic sync job to the scheduler."""
-    trigger = IntervalTrigger(seconds=60) if debug else CronTrigger(**parse_cron_env())
+    trigger = IntervalTrigger(seconds=60) if debug else parse_cron_env()
     scheduler.add_job(run_fn, trigger, max_instances=1)


### PR DESCRIPTION
## Summary
- parse CRON_EXPRESSION into a CronTrigger in F1
- adjust F1 scheduler to use new helper
- stub heavy modules in the unit test
- document known maintenance issues

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857aff44498832b9e5db8203a2c2daa