### PR TITLE
Add docs for F2–F9

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Home Index is a personal file search engine that syncs and enriches metadata.
 ## Features
 
 - [F1 "I want scheduled file sync"](docs/F1.md)
-- F2 "I want metadata stored by file ID"
-- F3 "I want each path linked to its metadata"
-- F4 "I want to detect duplicate files"
-- F5 "I want metadata for files on offline media"
-- F6 "I want to search my file metadata"
-- F7 "I want modules to enrich files"
-- F8 "I want those modules to run on other machines"
-- F9 "I want to search file chunks by concept"
+- [F2 "I want metadata stored by file ID"](docs/F2.md)
+- [F3 "I want each path linked to its metadata"](docs/F3.md)
+- [F4 "I want to detect duplicate files"](docs/F4.md)
+- [F5 "I want metadata for files on offline media"](docs/F5.md)
+- [F6 "I want to search my file metadata"](docs/F6.md)
+- [F7 "I want modules to enrich files"](docs/F7.md)
+- [F8 "I want those modules to run on other machines"](docs/F8.md)
+- [F9 "I want to search file chunks by concept"](docs/F9.md)
 
 ### Well-known modules
 
@@ -35,5 +35,4 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Planned Maintenance
 
-- Add documentation for features F2–F9.
 - Expand acceptance tests to cover all features.

--- a/docs/F1.md
+++ b/docs/F1.md
@@ -1,8 +1,8 @@
-# F1 "I want my home server to be available when I need it."
+# F1 "I want scheduled file sync"
 
 ## Value
 
-This feature ensures that home-index not only adheres to a predictable and configurable sync schedule, but also guarantees meaningful progress and data availability when it matters most—aligning directly with your desire for your server to "be available when you need it." By interpreting the cron expression at startup, the daemon spaces sync events precisely to avoid overuse of system resources (P₁), ensures that a critical mass of indexing activity happens soon after startup (P₂), and confirms that tangible results (indexed file metadata) are eventually produced even if the server is stopped early (P₃). Altogether, this contract offers strong assurances of timely responsiveness, visible output, and efficient operation, so your server delivers reliable, ready-to-use file metadata when you interact with it—without wasting energy or leaving you uncertain about whether it's doing its job.
+Scheduled sync keeps your server responsive while new files are indexed at predictable times. You can depend on fresh metadata appearing soon without constant manual effort.
 
 ## Specification
 

--- a/docs/F2.md
+++ b/docs/F2.md
@@ -1,0 +1,25 @@
+# F2 "I want metadata stored by file ID"
+
+## Value
+
+Storing metadata under a stable identifier ensures your catalog remains intact even when files move or get renamed. By detaching data from paths, the system prevents duplication and makes metadata retrieval straightforward, so you always find accurate details about your files.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `WRITE(id, m)`      | save metadata `m` for file ID `id` |
+| **input**  | `READ(id)`          | request metadata for `id` |
+| **output** | `META_WRITTEN(id)`  | file `metadata/by-id/{id}/document.json` exists |
+| **output** | `META_RETURNED(m)`  | JSON `m` read back from that path |
+
+---
+
+### Contract = P₁ ∧ P₂
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ persistence** | `G( WRITE(id, m) → F META_WRITTEN(id) )` | *Every write eventually results in a stored file.* |
+| **P₂ retrieval**   | `G( READ(id) → F META_RETURNED(m) )`    | *Every read eventually yields the metadata.* |

--- a/docs/F3.md
+++ b/docs/F3.md
@@ -1,0 +1,25 @@
+# F3 "I want each path linked to its metadata"
+
+## Value
+
+Paths change over time as files are reorganized. By keeping a reference from every location to the same metadata, Home Index lets you move files freely without losing track of their history or searchability.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `LINK(p, id)`       | register path `p` for file ID `id` |
+| **input**  | `QUERY(p)`          | request metadata for path `p` |
+| **output** | `PATH_LINKED(p)`    | symlink `metadata/by-path/{p}` → `../by-id/{id}` |
+| **output** | `RESULT(m)`         | metadata `m` returned to caller |
+
+---
+
+### Contract = P₁ ∧ P₂
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ mapping**   | `G( LINK(p, id) → F PATH_LINKED(p) )` | *Every link eventually creates a path record.* |
+| **P₂ lookup**    | `G( QUERY(p) → F RESULT(m) )`        | *Every query eventually produces metadata.* |

--- a/docs/F4.md
+++ b/docs/F4.md
@@ -1,0 +1,24 @@
+# F4 "I want to detect duplicate files"
+
+## Value
+
+Duplicates waste space and clutter search results. Automatically flagging identical content helps you reclaim storage and keep your catalog tidy without manual effort.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `SCAN(f)`           | examine file `f` |
+| **output** | `DUPLICATE(f, id)`  | `f` matches file ID `id` |
+| **output** | `UNIQUE(f)`         | `f` has no known duplicates |
+
+---
+
+### Contract = P₁ ∧ P₂
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ check** | `G( SCAN(f) → F (DUPLICATE(f, id) ∨ UNIQUE(f)) )` | *Scanning a file eventually yields a duplicate or unique result.* |
+| **P₂ consistency** | `G( DUPLICATE(f, id) → ¬UNIQUE(f) )` | *Once flagged duplicate, it isn't marked unique.* |

--- a/docs/F5.md
+++ b/docs/F5.md
@@ -1,0 +1,25 @@
+# F5 "I want metadata for files on offline media"
+
+## Value
+
+Sometimes you unplug drives or store discs away. Keeping their metadata accessible lets you remember what's on them without mounting them, so you know where to look when you need a file.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `IMPORT(id, m)`     | add metadata `m` for offline file ID `id` |
+| **input**  | `QUERY(id)`         | request metadata for `id` |
+| **output** | `OFFLINE_STORED(id)`| offline metadata saved |
+| **output** | `OFFLINE_RESULT(m)` | offline metadata returned |
+
+---
+
+### Contract = P₁ ∧ P₂
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ saved** | `G( IMPORT(id, m) → F OFFLINE_STORED(id) )` | *Imported data eventually persists.* |
+| **P₂ accessible** | `G( QUERY(id) → F OFFLINE_RESULT(m) )` | *Queries eventually yield offline metadata.* |

--- a/docs/F6.md
+++ b/docs/F6.md
@@ -1,0 +1,22 @@
+# F6 "I want to search my file metadata"
+
+## Value
+
+Searching quickly across all indexed metadata turns your collection into a useful reference. Rather than scrolling through folders, you can jump straight to the files that match your query.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `SEARCH(q)`         | POST `/indexes/files/search` with JSON `{ "q": q }` |
+| **output** | `RESULT_LIST(r)`    | HTTP 200 JSON with key `"hits"` mapping to list `r` |
+
+---
+
+### Contract = P₁
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ response** | `G( SEARCH(q) → F RESULT_LIST(r) )` | *Every search eventually returns a list of matches.* |

--- a/docs/F7.md
+++ b/docs/F7.md
@@ -1,0 +1,24 @@
+# F7 "I want modules to enrich files"
+
+## Value
+
+Specialized modules can extract text, generate thumbnails, or label content. Running them as part of indexing gives you richer data with minimal manual steps.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `ENQUEUE(id)`       | schedule enrichment for file ID `id` |
+| **output** | `MODULE_DONE(id)`   | modules log prints `* done` after processing `id` |
+| **output** | `DATA_READY(id)`    | enriched metadata stored for `id` |
+
+---
+
+### Contract = P₁ ∧ P₂
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ queued** | `G( ENQUEUE(id) → F MODULE_DONE(id) )` | *Every job eventually completes.* |
+| **P₂ stored** | `G( MODULE_DONE(id) → F DATA_READY(id) )` | *Completed jobs eventually store their data.* |

--- a/docs/F8.md
+++ b/docs/F8.md
@@ -1,0 +1,24 @@
+# F8 "I want those modules to run on other machines"
+
+## Value
+
+Offloading heavy tasks to other hosts keeps your main server responsive. Remote module execution spreads the workload and lets you scale enrichment using spare hardware.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `DISPATCH(id, h)`   | send job for file `id` to host `h` |
+| **output** | `REMOTE_DONE(id)`   | host finished processing `id` |
+| **output** | `REMOTE_DATA(id)`   | enriched data returned for `id` |
+
+---
+
+### Contract = P₁ ∧ P₂
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ delivery** | `G( DISPATCH(id, h) → F REMOTE_DONE(id) )` | *Dispatched jobs eventually report completion.* |
+| **P₂ return**   | `G( REMOTE_DONE(id) → F REMOTE_DATA(id) )` | *Completed jobs eventually send back their data.* |

--- a/docs/F9.md
+++ b/docs/F9.md
@@ -1,0 +1,25 @@
+# F9 "I want to search file chunks by concept"
+
+## Value
+
+Breaking large files into chunks and indexing their content lets you find information hidden deep inside. Concept-based search uncovers relevant passages even if you don't know the exact phrasing.
+
+## Specification
+
+### Vocabulary
+
+| Kind       | Syntax on the trace | Payload / meaning |
+| ---------- | ------------------- | ----------------- |
+| **input**  | `CHUNK(id, c)`      | add chunk `c` for file ID `id` |
+| **input**  | `CONCEPT(q)`        | POST `/indexes/file_chunks/search` with JSON `{ "q": q }` |
+| **output** | `CHUNK_INDEXED(id)` | chunk indexed for `id` |
+| **output** | `CHUNK_RESULTS(r)`  | JSON results `r` from the search response |
+
+---
+
+### Contract = P₁ ∧ P₂
+
+| Label | MTL formula | Natural-language reading |
+| ----- | ----------- | ----------------------- |
+| **P₁ index** | `G( CHUNK(id, c) → F CHUNK_INDEXED(id) )` | *Every added chunk eventually indexes.* |
+| **P₂ search** | `G( CONCEPT(q) → F CHUNK_RESULTS(r) )` | *Concept queries eventually return relevant chunks.* |


### PR DESCRIPTION
## Summary
- document all remaining feature slices
- link features in README
- remove the documentation todo from Planned Maintenance
- fix F1 docs title and style
- clarify definitions in F2–F9 documentation

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858447d1780832bb241d406048c3a33