### PR TITLE
Maintenance fixes on F1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
 - Expand acceptance tests to cover all features.
 - Rewrite remaining feature docs to conform to AGENTS.md.
+- Add missing documentation for features F2–F9 and corresponding tests.

--- a/packages/home_index/main.py
+++ b/packages/home_index/main.py
@@ -123,9 +123,9 @@ MEILISEARCH_CHUNK_INDEX_NAME = os.environ.get(
     "file_chunks",
 )
 
-CPU_COUNT = os.cpu_count()
-MAX_HASH_WORKERS = int(os.environ.get("MAX_HASH_WORKERS", CPU_COUNT / 2))
-MAX_FILE_WORKERS = int(os.environ.get("MAX_FILE_WORKERS", CPU_COUNT / 2))
+CPU_COUNT = os.cpu_count() or 1
+MAX_HASH_WORKERS = int(os.environ.get("MAX_HASH_WORKERS", CPU_COUNT // 2))
+MAX_FILE_WORKERS = int(os.environ.get("MAX_FILE_WORKERS", CPU_COUNT // 2))
 
 # embedding configuration
 EMBED_MODEL_NAME = os.environ.get("EMBED_MODEL_NAME", "intfloat/e5-small-v2")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -2,6 +2,8 @@ import ast
 import pathlib
 import os
 import time
+from typing import List
+
 import pytest
 
 # Importing only the retry helper via AST avoids executing side effects in the
@@ -10,7 +12,7 @@ import pytest
 # Extract retry_until_ready function without importing entire module
 SRC = pathlib.Path("packages/home_index/main.py").read_text()
 module = ast.parse(SRC)
-nodes = []
+nodes: List[ast.AST] = []
 for node in module.body:
     if (
         isinstance(node, ast.Assign)


### PR DESCRIPTION
## Summary
- silence mypy errors when CPU count is missing
- keep retry unit test typed correctly
- note missing docs/tests for remaining features

## Testing
- `./agents-check.sh`
- `pytest features/F1/test/acceptance.py::test_indexing_runs_on_schedule -vv` *(fails: FileNotFoundError: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_685869954148832b90ac79903fdd92a4