### PR TITLE
Fix CI workflow naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release-image
+name: release
 
 on:
   release:
@@ -12,20 +12,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Log in to Docker Hub
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Generate tags & labels (e.g. v1.2.3, latest)
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
 
-      # Build and push the image
       - uses: docker/build-push-action@v4
         with:
           context: .
@@ -34,5 +31,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # Show final tag(s) in the run summary
       - run: echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test-features
+name: test
 
 on: [push]
 
@@ -15,15 +15,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose
 
-      # Dev container
       - run: docker-compose -f .devcontainer/docker-compose.yml up --build -d
       - run: docker exec ${REPO}-devcontainer postStart.sh
       - run: docker exec ${REPO}-devcontainer ./check.sh
 
-      # Build release image for acceptance tests
       - run: docker exec ${REPO}-devcontainer docker build -f Dockerfile -t ${REPO}:ci .
 
-      # Acceptance tests
       - run: |
           set -euo pipefail
           FEATURES=$(ls features | grep '^F')


### PR DESCRIPTION
## Summary
- rename `test-features` workflow to `test`
- rename `release-image` workflow to `release`
- drop comments so the YAML matches the reference examples

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68587d0ba0ec832b87bba23ec89228f0