### PR TITLE
Speed up F1 acceptance

### DIFF
--- a/docs/F1.md
+++ b/docs/F1.md
@@ -8,7 +8,7 @@ Scheduled sync keeps your server responsive while new files are indexed at predi
 
 ## Usage
 
-Provide a [cron expression](https://crontab.guru/) in the CRON_EXPRESSION environment variable to the container at startup using a docker-compose.yml file or similar.
+Provide a [cron expression](https://crontab.guru/) in the CRON_EXPRESSION environment variable to the container at startup using a docker-compose.yml file or similar. Both five- and six‑field formats are supported; include a seconds field for faster intervals, e.g. `CRON_EXPRESSION=*/10 * * * * *`.
 
 ---
 

--- a/features/F1/scheduler.py
+++ b/features/F1/scheduler.py
@@ -14,17 +14,26 @@ def parse_cron_env(
     """Return CronTrigger kwargs from the CRON_EXPRESSION environment variable."""
     cron_expression = os.getenv(env_var, default)
     parts = cron_expression.split()
-    if len(parts) != 5:
-        raise ValueError(
-            f"Invalid cron expression in {env_var}: '{cron_expression}'. Must have 5 fields."
-        )
-    return {
-        "minute": parts[0],
-        "hour": parts[1],
-        "day": parts[2],
-        "month": parts[3],
-        "day_of_week": parts[4],
-    }
+    if len(parts) == 5:
+        return {
+            "minute": parts[0],
+            "hour": parts[1],
+            "day": parts[2],
+            "month": parts[3],
+            "day_of_week": parts[4],
+        }
+    if len(parts) == 6:
+        return {
+            "second": parts[0],
+            "minute": parts[1],
+            "hour": parts[2],
+            "day": parts[3],
+            "month": parts[4],
+            "day_of_week": parts[5],
+        }
+    raise ValueError(
+        f"Invalid cron expression in {env_var}: '{cron_expression}'. Must have 5 or 6 fields."
+    )
 
 
 def attach_sync_job(


### PR DESCRIPTION
## Summary
- allow 6-field cron expressions for sub-minute schedules
- simplify F1 acceptance test to use second-based cron
- clarify cron expression support in docs

## Testing
- `./agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68588a739fe0832ba67d044a7336aa6d