### PR TITLE
Enable strict typing on F1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 - Rewrite remaining feature docs to conform to AGENTS.md.
 - Add missing documentation for features F2–F9 and corresponding tests.
 - Audit Dockerfiles for any remaining unused dependencies.
+- Apply strict typing across the remaining codebase.

--- a/check.sh
+++ b/check.sh
@@ -14,4 +14,5 @@ fi
 black --check .
 ruff check .
 mypy --ignore-missing-imports --explicit-package-bases packages tests || true
+mypy --ignore-missing-imports --strict --explicit-package-bases features/F1
 pytest -q

--- a/features/F1/test/acceptance.py
+++ b/features/F1/test/acceptance.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 from apscheduler.triggers.cron import CronTrigger
+from typing import cast
 
 
 def _parse_cron(cron: str) -> dict[str, str]:
@@ -33,8 +34,14 @@ def _expected_interval(cron: str) -> float:
     trigger = CronTrigger(**_parse_cron(cron))
     now = datetime.now(trigger.timezone)
     first = trigger.get_next_fire_time(None, now)
+    if first is None:
+        raise ValueError("CronTrigger failed to produce first fire time")
     second = trigger.get_next_fire_time(first, first)
-    return (second - first).total_seconds()
+    if second is None:
+        raise ValueError("CronTrigger failed to produce second fire time")
+    first_dt = cast(datetime, first)
+    second_dt = cast(datetime, second)
+    return (second_dt - first_dt).total_seconds()
 
 
 def _run_once(


### PR DESCRIPTION
## Summary
- add strict typing check for feature F1
- ensure cron interval calculation is typed
- run mypy strict against F1 module
- note strict typing in planned maintenance

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68589742bc94832baa657b3139a13179