### PR TITLE
Implement path search support

### DIFF
--- a/docs/F2.md
+++ b/docs/F2.md
@@ -8,8 +8,8 @@ Searching the index lets you quickly surface individual files even when duplicat
 
 ## Usage
 
-When the container indexes your files, each document is stored under `metadata/by-id/<file-id>/document.json` and every path gets a symlink in `metadata/by-path/`. The `<file-id>` value is an xxhash64 digest of the file contents. Duplicate files share one document whose `paths` map lists all locations and the `copies` field counts them. This field is filterable so you can query unique files directly or search for duplicates.
-The search index exposes `copies` as a filterable attribute.
+When the container indexes your files, each document is stored under `metadata/by-id/<file-id>/document.json` and every path gets a symlink in `metadata/by-path/`. The `<file-id>` value is an xxhash64 digest of the file contents. Duplicate files share one document whose `paths` map lists all locations and the `copies` field counts them. The document also contains a `paths_list` array with every relative path which lets you filter by exact path or search for paths as text.
+The search index exposes `copies` and `paths_list` as filterable attributes.
 
 ```bash
 curl -X POST 'http://localhost:7700/indexes/files/search' \
@@ -99,10 +99,18 @@ Query Meilisearch to fetch the unique file by its metadata:
 ```bash
 curl -X POST 'http://localhost:7700/indexes/files/search' \
   -H 'Content-Type: application/json' \
-  --data '{"q": "", "filter": "paths.c.txt EXISTS"}'
+  --data '{"q": "", "filter": "paths_list = \"c.txt\""}'
 ```
 
 The returned document lists only `c.txt` with `"copies": 1`.
+
+You can also search by path text:
+
+```bash
+curl -X POST 'http://localhost:7700/indexes/files/search' \
+  -H 'Content-Type: application/json' \
+  --data '{"q": "c.txt"}'
+```
 
 You can verify duplicates with another search:
 
@@ -145,13 +153,13 @@ Filtering on `size` or `type` works the same way.
 
 | **Your single action** | **What you will literally see** |
 | --- | --- |
-| Run `docker compose up -d` with a mix of duplicate and unique files in `./input/` | Each unique file gets a single folder under `./output/metadata/by-id/` while all its paths appear as symlinks under `./output/metadata/by-path/`. Searches using `id`, `paths.*`, `mtime`, `size`, `type`, or `copies` all return the same document, and multi-field filters combine these conditions. |
+| Run `docker compose up -d` with a mix of duplicate and unique files in `./input/` | Each unique file gets a single folder under `./output/metadata/by-id/` while all its paths appear as symlinks under `./output/metadata/by-path/`. Searches using `id`, `paths_list`, `mtime`, `size`, `type`, or `copies` all return the same document, and multi-field filters combine these conditions. |
 
 ---
 
 ## Acceptance
 
 1. When duplicates exist in `./input/`, exactly one directory per unique file appears under `./output/metadata/by-id/` and each path under `./output/metadata/by-path/` resolves to a directory.
-2. Each `document.json` includes `id`, `paths`, `mtime`, `size`, `type`, and `copies` fields with expected values.
+2. Each `document.json` includes `id`, `paths`, `paths_list`, `mtime`, `size`, `type`, and `copies` fields with expected values.
 3. Querying the search index for every individual field returns the corresponding document.
 4. Multi-field filters like `size = 7 AND copies = 1` and `type = "text/plain" AND copies = 2` return the expected results.

--- a/features/F2/metadata_store.py
+++ b/features/F2/metadata_store.py
@@ -32,9 +32,6 @@ def ensure_directories() -> None:
 
 def write_doc_json(doc: MutableMapping[str, Any]) -> None:
     """Write ``doc`` as JSON under ``BY_ID_DIRECTORY``."""
-    from home_index import main as hi
-
-    hi.migrate_doc(doc)
     ensure_directories()
     target_dir = by_id_directory() / str(doc["id"])
     target_dir.mkdir(parents=True, exist_ok=True)

--- a/features/F2/metadata_store.py
+++ b/features/F2/metadata_store.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Mapping, Any
+from typing import MutableMapping, Any
+
+
+def _add_paths_list(doc: MutableMapping[str, Any]) -> None:
+    """Populate ``paths_list`` and update the schema version."""
+    doc["paths_list"] = sorted(doc.get("paths", {}).keys())
+    doc["version"] = 1
 
 
 def metadata_directory() -> Path:
@@ -24,8 +30,11 @@ def ensure_directories() -> None:
         path.mkdir(parents=True, exist_ok=True)
 
 
-def write_doc_json(doc: Mapping[str, Any]) -> None:
+def write_doc_json(doc: MutableMapping[str, Any]) -> None:
     """Write ``doc`` as JSON under ``BY_ID_DIRECTORY``."""
+    from home_index import main as hi
+
+    hi.migrate_doc(doc)
     ensure_directories()
     target_dir = by_id_directory() / str(doc["id"])
     target_dir.mkdir(parents=True, exist_ok=True)

--- a/features/F2/test/migration_helper.py
+++ b/features/F2/test/migration_helper.py
@@ -48,7 +48,11 @@ def simulate_v0_and_rerun(
         for doc_dir in by_id_dir.iterdir():
             if not doc_dir.is_dir():
                 continue
-            doc = json.loads((doc_dir / "document.json").read_text())
+            try:
+                doc = json.loads((doc_dir / "document.json").read_text())
+            except json.JSONDecodeError:
+                all_migrated = False
+                break
             if "paths_list" not in doc or "version" not in doc:
                 all_migrated = False
                 break

--- a/features/F2/test/migration_helper.py
+++ b/features/F2/test/migration_helper.py
@@ -68,7 +68,14 @@ def simulate_v0_and_rerun(
     for doc_dir in by_id_dir.iterdir():
         if not doc_dir.is_dir():
             continue
-        doc = json.loads((doc_dir / "document.json").read_text())
-        assert "paths_list" in doc and "version" in doc
+        doc_path = doc_dir / "document.json"
+        deadline = time.time() + 30
+        while True:
+            doc = json.loads(doc_path.read_text())
+            if "paths_list" in doc and "version" in doc:
+                break
+            if time.time() > deadline:
+                raise AssertionError(f"Timed out waiting for migration: {doc_path}")
+            time.sleep(0.5)
 
     return by_id_dir, by_path_dir, dup_docs, unique_docs

--- a/features/F2/test/migration_helper.py
+++ b/features/F2/test/migration_helper.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+
+def simulate_v0_and_rerun(
+    compose_file: Path,
+    workdir: Path,
+    output_dir: Path,
+    run_again: Callable[
+        [Path, Path, Path],
+        tuple[Path, Path, list[dict[str, Any]], list[dict[str, Any]]],
+    ],
+) -> tuple[Path, Path, list[dict[str, Any]], list[dict[str, Any]]]:
+    """Downgrade docs to schema v0, rerun the container, and confirm migration."""
+    by_id_dir = output_dir / "metadata" / "by-id"
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(compose_file),
+            "stop",
+        ],
+        check=True,
+        cwd=workdir,
+    )
+    for doc_dir in by_id_dir.iterdir():
+        if not doc_dir.is_dir():
+            continue
+        doc_path = doc_dir / "document.json"
+        data = json.loads(doc_path.read_text())
+        data.pop("paths_list", None)
+        data.pop("version", None)
+        doc_path.write_text(json.dumps(data))
+
+    by_id_dir, by_path_dir, dup_docs, unique_docs = run_again(
+        compose_file, workdir, output_dir
+    )
+
+    for doc_dir in by_id_dir.iterdir():
+        doc = json.loads((doc_dir / "document.json").read_text())
+        assert "paths_list" in doc and "version" in doc
+
+    return by_id_dir, by_path_dir, dup_docs, unique_docs

--- a/features/F2/test/migration_helper.py
+++ b/features/F2/test/migration_helper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import time
 from pathlib import Path
 from typing import Any, Callable
 
@@ -41,8 +42,20 @@ def simulate_v0_and_rerun(
         compose_file, workdir, output_dir
     )
 
-    for doc_dir in by_id_dir.iterdir():
-        doc = json.loads((doc_dir / "document.json").read_text())
-        assert "paths_list" in doc and "version" in doc
+    deadline = time.time() + 120
+    while True:
+        all_migrated = True
+        for doc_dir in by_id_dir.iterdir():
+            if not doc_dir.is_dir():
+                continue
+            doc = json.loads((doc_dir / "document.json").read_text())
+            if "paths_list" not in doc or "version" not in doc:
+                all_migrated = False
+                break
+        if all_migrated:
+            break
+        if time.time() > deadline:
+            raise AssertionError("Timed out waiting for migrated documents")
+        time.sleep(0.5)
 
     return by_id_dir, by_path_dir, dup_docs, unique_docs

--- a/tests/test_archive_support.py
+++ b/tests/test_archive_support.py
@@ -39,7 +39,7 @@ def test_metadata_persists_if_the_archive_directory_is_temporarily_missing(
 
     importlib.reload(hi)
 
-    md, mhr, ua_docs, ua_hashes = hi.index_metadata()
+    md, mhr, ua_docs, ua_hashes, _ = hi.index_metadata()
     assert doc["id"] in ua_docs
 
     files_docs, hashes = hi.index_files(md, mhr, ua_docs, ua_hashes)

--- a/tests/test_metadata_migration.py
+++ b/tests/test_metadata_migration.py
@@ -1,0 +1,20 @@
+import importlib
+
+
+def test_migrate_doc_adds_paths_list():
+    import home_index.main as hi
+
+    importlib.reload(hi)
+
+    doc = {"id": "1", "paths": {"a.txt": 1.0}}
+    assert hi.migrate_doc(doc)
+    assert doc["paths_list"] == ["a.txt"]
+    assert doc["version"] == hi.CURRENT_VERSION
+
+    doc2 = {
+        "id": "2",
+        "paths": {"b.txt": 1.0},
+        "paths_list": ["b.txt"],
+        "version": hi.CURRENT_VERSION,
+    }
+    assert not hi.migrate_doc(doc2)


### PR DESCRIPTION
## Summary
- refactor metadata schema migrations into `home_index.main`
- update metadata_store to rely on shared migration helpers
- ensure migrations run during F2 acceptance
- add unit test for migrate_doc
- collect migration test logic into helper module
- remove unused VERSION constant

## Testing
- `./agents-check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b157eaf54832b85d0d126004af643