### PR TITLE
Refactor F1 and F2-specific logic

### DIFF
--- a/features/F2/__init__.py
+++ b/features/F2/__init__.py
@@ -1,5 +1,5 @@
 """Feature F2 package."""
 
-from . import duplicate_finder, metadata_store, path_links
+from . import duplicate_finder, metadata_store, path_links, migrations
 
-__all__ = ["metadata_store", "path_links", "duplicate_finder"]
+__all__ = ["metadata_store", "path_links", "duplicate_finder", "migrations"]

--- a/features/F2/migrations.py
+++ b/features/F2/migrations.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import MutableMapping, Any
+
+from . import metadata_store
+
+# List of migration functions to upgrade stored metadata documents.
+MIGRATIONS = [metadata_store._add_paths_list]
+
+# Schema version corresponding to the last migration in ``MIGRATIONS``.
+CURRENT_VERSION = len(MIGRATIONS)
+
+
+def migrate_doc(doc: MutableMapping[str, Any]) -> bool:
+    """Apply pending migrations to ``doc`` in-place."""
+    version = doc.get("version", 0)
+    migrated = False
+    while version < CURRENT_VERSION:
+        MIGRATIONS[version](doc)
+        migrated = True
+        version = doc.get("version", version + 1)
+    return migrated

--- a/packages/home_index/main.py
+++ b/packages/home_index/main.py
@@ -67,7 +67,6 @@ import time
 
 import magic
 import copy
-from typing import MutableMapping, Any
 import sys
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from itertools import chain
@@ -86,21 +85,11 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from features.F1 import scheduler
-from features.F2 import duplicate_finder, metadata_store, path_links
+from features.F2 import duplicate_finder, metadata_store, path_links, migrations
 
-MIGRATIONS = [metadata_store._add_paths_list]
-CURRENT_VERSION = len(MIGRATIONS)
-
-
-def migrate_doc(doc: MutableMapping[str, Any]) -> bool:
-    """Apply pending migrations to ``doc`` in-place."""
-    version = doc.get("version", 0)
-    migrated = False
-    while version < CURRENT_VERSION:
-        MIGRATIONS[version](doc)
-        migrated = True
-        version = doc.get("version", version + 1)
-    return migrated
+# Expose F2 migration helpers for external use and unit tests.
+migrate_doc = migrations.migrate_doc
+CURRENT_VERSION = migrations.CURRENT_VERSION
 
 
 magic_mime = magic.Magic(mime=True)


### PR DESCRIPTION
## Summary
- move metadata migration helpers to `features/F2`
- expose `migrate_doc` and `CURRENT_VERSION` via `features.F2.migrations`
- re-export migration helpers from `home_index.main`

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b4e4cd054832b89c80759019fa72a