### PR TITLE
Enable Docker layer cache in CI

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   devcontainer:
+    image: home-index-devcontainer
     build:
       context: .
       dockerfile: Dockerfile.devcontainer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       DC: docker compose -f .devcontainer/docker-compose.yml
 
     steps:
-      - uses: docker/setup-buildx-action@v3.5.1
+      - uses: docker/setup-buildx-action@v3.11.1
       - uses: actions/checkout@v4
 
       - name: Cache Docker layers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
           export DC="docker compose -f .devcontainer/docker-compose.yml"
 
           docker buildx build \
-            --file .devcontainer/Dockerfile.devcontainer \
+            --file Dockerfile.devcontainer \
             --tag home-index-devcontainer \
             --cache-from type=local,src=${{ runner.temp }}/buildx-cache \
             --cache-to   type=local,dest=${{ runner.temp }}/buildx-cache,mode=max \
             --load \
-            .
+            .devcontainer
 
           $DC up -d --no-build
           $DC exec devcontainer postStart.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
           export DC="docker compose -f .devcontainer/docker-compose.yml"
 
           docker buildx build \
-            --file Dockerfile.devcontainer \
+            --file .devcontainer/Dockerfile.devcontainer \
             --tag home-index-devcontainer \
             --cache-from type=local,src=${{ runner.temp }}/buildx-cache \
             --cache-to   type=local,dest=${{ runner.temp }}/buildx-cache,mode=max \
             --load \
-            .devcontainer
+            .
 
           $DC up -d --no-build
           $DC exec devcontainer postStart.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,15 @@ jobs:
         run: |
           export DC="docker compose -f .devcontainer/docker-compose.yml"
 
-          $DC build --progress=plain \
+          docker buildx build \
+            --file .devcontainer/Dockerfile.devcontainer \
+            --tag home-index-devcontainer \
             --cache-from type=local,src=${{ runner.temp }}/buildx-cache \
-            --cache-to   type=local,dest=${{ runner.temp }}/buildx-cache,mode=max
+            --cache-to   type=local,dest=${{ runner.temp }}/buildx-cache,mode=max \
+            --load \
+            .
 
-          $DC up -d
+          $DC up -d --no-build
           $DC exec devcontainer postStart.sh
           $DC exec devcontainer ./check.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,32 +1,59 @@
 name: test
-
-on: [push]
+on: push
 
 jobs:
   test:
     runs-on: ubuntu-latest
     env:
       REPO: ${{ github.event.repository.name }}
+      DOCKER_BUILDKIT: 1
+      COMPOSE_DOCKER_CLI_BUILD: 1
+      DC: docker compose -f .devcontainer/docker-compose.yml
+
     steps:
+      - uses: docker/setup-buildx-action@v3.5.1
       - uses: actions/checkout@v4
 
-      - name: Install docker-compose
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: ${{ runner.temp }}/buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ github.ref }}
+
+      - name: Build & start devcontainer with cache
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
+          export DC="docker compose -f .devcontainer/docker-compose.yml"
 
-      - run: docker-compose -f .devcontainer/docker-compose.yml up --build -d
-      - run: docker exec ${REPO}-devcontainer postStart.sh
-      - run: docker exec ${REPO}-devcontainer ./check.sh
+          $DC build --progress=plain \
+            --cache-from type=local,src=${{ runner.temp }}/buildx-cache \
+            --cache-to   type=local,dest=${{ runner.temp }}/buildx-cache,mode=max
 
-      - run: docker exec ${REPO}-devcontainer docker build -f Dockerfile -t ${REPO}:ci .
+          $DC up -d
+          $DC exec devcontainer postStart.sh
+          $DC exec devcontainer ./check.sh
 
-      - run: |
-          set -euo pipefail
-          FEATURES=$(ls features | grep '^F')
-          for f in $FEATURES; do
-            docker exec -e IMAGE=${REPO}:ci ${REPO}-devcontainer \
-              bash -lc "source venv/bin/activate && pytest -q features/${f}/test/acceptance.py"
+      - name: Build CI image with cache
+        uses: docker/build-push-action@v3.3.0
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          tags: ${{ env.REPO }}:ci
+          cache-from: type=local,src=${{ runner.temp }}/buildx-cache
+          cache-to:   type=local,dest=${{ runner.temp }}/buildx-cache,mode=max
+
+      - name: Run acceptance tests
+        shell: bash
+        run: |
+          export DC="docker compose -f .devcontainer/docker-compose.yml"
+          for f in features/F*; do
+            $DC exec -e IMAGE=${{ env.REPO }}:ci devcontainer \
+              bash -lc "source venv/bin/activate && pytest -q $f/test/acceptance.py" || status=$?
           done
+          exit $status
 
-      - run: docker-compose -f .devcontainer/docker-compose.yml down -v
+      - name: Tear down devcontainer
+        run: docker compose -f .devcontainer/docker-compose.yml down -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             --cache-from type=local,src=${{ runner.temp }}/buildx-cache \
             --cache-to   type=local,dest=${{ runner.temp }}/buildx-cache,mode=max \
             --load \
-            .
+            .devcontainer
 
           $DC up -d --no-build
           $DC exec devcontainer postStart.sh

--- a/README.md
+++ b/README.md
@@ -35,4 +35,3 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 - Expand acceptance tests to cover all features.
 - Rewrite remaining feature docs to conform to AGENTS.md.
 - Add missing documentation for features F3–F6 and corresponding tests.
-- Audit Dockerfiles for any remaining unused dependencies.


### PR DESCRIPTION
## Summary
- use actions/cache to persist docker layers across workflow runs
- build Docker images with cache enabled
- drop completed task from Planned Maintenance

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b7d8130a0832b89a09dc08ddfbd85