### PR TITLE
Add archive flags to file documents

### DIFF
--- a/docs/F3.md
+++ b/docs/F3.md
@@ -13,6 +13,9 @@ When a drive is not mounted, the sync process leaves any existing documents and 
 
 Metadata migrations from Feature F2 still run on these stored documents so the schema stays current. Feature F4 modules only process a file when at least one of its paths is available.
 
+On every sync Home Index updates two flags for each document:
+`has_archive_paths` signals that at least one path lives under `ARCHIVE_DIRECTORY` and `offline` becomes `true` when **all** those archive paths are currently unavailable. Both fields persist alongside the rest of the metadata and are exposed in Meilisearch so the search index always reflects the current archive state.
+
 ---
 
 ## Minimal `docker-compose.yml`
@@ -73,3 +76,4 @@ The first run indexes the file. When the drive is absent the second run leaves t
 
 1. Metadata for paths inside `ARCHIVE_DIRECTORY` is retained when the files are absent.
 2. When an archived file is removed and sync runs again, its document and symlink are deleted.
+3. Each document stores `has_archive_paths` and `offline` fields that update to reflect the current state every time sync runs.

--- a/docs/meilisearch_document.schema.json
+++ b/docs/meilisearch_document.schema.json
@@ -32,12 +32,29 @@
       "type": "number",
       "description": "Most recent modification time across all copies (epoch seconds truncated to 4 decimals)"
     },
+    "has_archive_paths": {
+      "type": "boolean",
+      "description": "True when any path for the document is inside ARCHIVE_DIRECTORY"
+    },
+    "offline": {
+      "type": "boolean",
+      "description": "True when all archive paths are currently unavailable"
+    },
     "next": {
       "type": "string",
       "description": "Name of the next module to process this document or empty string when none",
       "default": ""
     }
   },
-  "required": ["id", "type", "size", "paths", "copies", "mtime"],
+  "required": [
+    "id",
+    "type",
+    "size",
+    "paths",
+    "copies",
+    "mtime",
+    "has_archive_paths",
+    "offline"
+  ],
   "additionalProperties": true
 }

--- a/docs/sample_document.json
+++ b/docs/sample_document.json
@@ -5,5 +5,7 @@
   "paths": {"file.txt": 1700000000},
   "copies": 1,
   "mtime": 1700000000,
+  "has_archive_paths": false,
+  "offline": false,
   "next": ""
 }

--- a/features/F3/archive.py
+++ b/features/F3/archive.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping, MutableMapping
 
 __all__ = [
     "archive_directory",
     "path_from_relpath",
     "is_in_archive_dir",
     "doc_is_online",
+    "update_archive_flags",
 ]
 
 
@@ -28,10 +29,19 @@ def is_in_archive_dir(path: Path) -> bool:
     return archive_directory() in path.parents
 
 
-def doc_is_online(doc: dict[str, Any]) -> bool:
+def doc_is_online(doc: Mapping[str, Any]) -> bool:
     """Return True if ``doc`` has at least one path accessible on disk."""
     for relpath in doc.get("paths", {}).keys():
         path = path_from_relpath(relpath)
         if not is_in_archive_dir(path) or path.exists():
             return True
     return False
+
+
+def update_archive_flags(doc: MutableMapping[str, Any]) -> None:
+    """Populate archive-related flags on ``doc`` in place."""
+    doc["has_archive_paths"] = any(
+        is_in_archive_dir(path_from_relpath(relpath))
+        for relpath in doc.get("paths", {}).keys()
+    )
+    doc["offline"] = not doc_is_online(doc)

--- a/features/F3/test/acceptance.py
+++ b/features/F3/test/acceptance.py
@@ -158,6 +158,8 @@ def test_offline_archive_workflow(tmp_path: Path) -> None:
         ).is_symlink()
         docs = _search_meili(f'id = "{offline_id}"', compose_file, workdir, output_dir)
         assert any(doc["id"] == offline_id for doc in docs)
+        assert all(doc["offline"] for doc in docs)
+        assert all(doc["has_archive_paths"] for doc in docs)
 
         subprocess.run(
             ["docker", "compose", "-f", str(compose_file), "stop"],
@@ -181,6 +183,8 @@ def test_offline_archive_workflow(tmp_path: Path) -> None:
 
         docs = _search_meili(f'id = "{online_id}"', compose_file, workdir, output_dir)
         assert any(doc["id"] == online_id for doc in docs)
+        assert all(not doc["offline"] for doc in docs)
+        assert all(doc["has_archive_paths"] for doc in docs)
 
         doc_dir = output_dir / "metadata" / "by-id" / offline_id
         assert not doc_dir.exists()

--- a/tests/test_archive_support.py
+++ b/tests/test_archive_support.py
@@ -44,6 +44,13 @@ def test_metadata_persists_if_the_archive_directory_is_temporarily_missing(
 
     files_docs, hashes = hi.index_files(md, mhr, ua_docs, ua_hashes)
     assert doc["id"] in files_docs
+    assert files_docs[doc["id"]]["has_archive_paths"]
+    assert files_docs[doc["id"]]["offline"]
+
+    hi.update_metadata(md, mhr, files_docs, hashes)
+    persisted = json.loads((by_id / doc["id"] / "document.json").read_text())
+    assert persisted["has_archive_paths"]
+    assert persisted["offline"]
 
 
 def test_metadata_and_symlinks_are_purged_after_an_archive_file_is_removed(


### PR DESCRIPTION
## Summary
- expose `update_archive_flags` in F3 archive utils
- compute `has_archive_paths` and `offline` for every document
- persist the flags after module runs
- extend Meilisearch document schema and docs
- assert the fields in archive tests
- ensure flags are written whenever they change during sync
- clarify F3 docs with new required fields

## Testing
- `./agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685cea5e1cb8832b8571b08b50934a8d