### PR TITLE
Restructure without compatibility package

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             },
             "pathMappings": [
                 {
-                    "localRoot": "${workspaceFolder}/packages/home_index",
+                    "localRoot": "${workspaceFolder}",
                     "remoteRoot": "/app"
                 }
             ],

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ AutoTokenizer.from_pretrained("intfloat/e5-small-v2")
 SentenceTransformer("intfloat/e5-small-v2")
 EOF
 
-COPY packages/home_index ./home_index
+COPY main.py ./
+COPY shared ./shared
 COPY features ./features
-ENTRYPOINT ["python3", "-m", "home_index"]
+ENTRYPOINT ["python3", "main.py"]

--- a/README.md
+++ b/README.md
@@ -36,4 +36,3 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 - Rewrite remaining feature docs to conform to AGENTS.md.
 - Add missing documentation for features F5–F6 and corresponding tests.
 - Audit Dockerfiles for any remaining unused dependencies.
-- Review docker-compose mounts after removing `bind-mounts` directory.

--- a/check.sh
+++ b/check.sh
@@ -16,7 +16,7 @@ fi
 
 black --check .
 ruff check .
-mypy --ignore-missing-imports --explicit-package-bases --no-site-packages packages tests || true
+mypy --ignore-missing-imports --explicit-package-bases --no-site-packages main.py shared tests || true
 mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F1
 mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F2
 mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,14 @@ services:
     container_name: home-index
     depends_on:
       - meilisearch
-      - home-index-example-module
     environment:
       - DEBUG=True
       - MEILISEARCH_HOST=http://meilisearch:7700
-      - MODULES=http://home-index-example-module:9000
       - TZ=America/Los_Angeles
     restart: unless-stopped
     volumes:
-      - ./bind-mounts/home-index:/home-index
-      - ./bind-mounts/files:/files
+      - ./docker-data/home-index:/home-index
+      - ./docker-data/files:/files
   meilisearch:
     container_name: meilisearch
     environment:
@@ -26,14 +24,4 @@ services:
     ports:
       - "7700:7700"
     volumes:
-      - ./bind-mounts/meilisearch:/meili_data
-  home-index-example-module:
-    build:
-      context: ./features/F4/module_template/
-      dockerfile: Dockerfile
-    container_name: home-index-example-module
-    environment:
-      - TZ=America/Los_Angeles
-    restart: unless-stopped
-    volumes:
-      - ./bind-mounts/files:/files
+      - ./docker-data/meilisearch:/meili_data

--- a/features/F4/modules.py
+++ b/features/F4/modules.py
@@ -7,7 +7,8 @@ import logging.handlers
 import os
 import time
 from pathlib import Path
-from typing import Any, Mapping, Callable, TypeVar, cast, TYPE_CHECKING
+import importlib
+from typing import Any, Mapping, Callable, TypeVar, cast
 from xmlrpc.client import Fault, ServerProxy
 
 from features.F2.metadata_store import (
@@ -16,13 +17,6 @@ from features.F2.metadata_store import (
     write_doc_json,
 )
 from features.F3.archive import doc_is_online, update_archive_flags
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-
-    hi: Any
-else:
-    import main as hi
 
 LOGGING_LEVEL = os.environ.get("LOGGING_LEVEL", "INFO")
 LOGGING_MAX_BYTES = int(os.environ.get("LOGGING_MAX_BYTES", 5_000_000))
@@ -158,6 +152,11 @@ def metadata_dir_relpath_from_doc(name: str, document: Mapping[str, Any]) -> Pat
 
 
 async def update_doc_from_module(document: dict[str, Any]) -> dict[str, Any]:
+    try:
+        from home_index import main as hi
+    except Exception:  # pragma: no cover - compatibility
+        hi = importlib.import_module("main")
+    hi = cast(Any, hi)
 
     next_module_name = ""
     found_previous_next = False
@@ -211,6 +210,11 @@ def set_next_modules(files_docs_by_hash: dict[str, dict[str, Any]]) -> None:
 
 
 async def run_module(name: str, proxy: ServerProxy) -> bool:
+    try:
+        from home_index import main as hi
+    except Exception:  # pragma: no cover - compatibility
+        hi = importlib.import_module("main")
+    hi = cast(Any, hi)
 
     try:
         documents = await hi.get_all_pending_jobs(name)

--- a/features/F4/modules.py
+++ b/features/F4/modules.py
@@ -7,7 +7,7 @@ import logging.handlers
 import os
 import time
 from pathlib import Path
-from typing import Any, Mapping, Callable, TypeVar, cast
+from typing import Any, Mapping, Callable, TypeVar, cast, TYPE_CHECKING
 from xmlrpc.client import Fault, ServerProxy
 
 from features.F2.metadata_store import (
@@ -16,6 +16,13 @@ from features.F2.metadata_store import (
     write_doc_json,
 )
 from features.F3.archive import doc_is_online, update_archive_flags
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Any
+
+    hi: Any
+else:
+    import main as hi
 
 LOGGING_LEVEL = os.environ.get("LOGGING_LEVEL", "INFO")
 LOGGING_MAX_BYTES = int(os.environ.get("LOGGING_MAX_BYTES", 5_000_000))
@@ -151,7 +158,6 @@ def metadata_dir_relpath_from_doc(name: str, document: Mapping[str, Any]) -> Pat
 
 
 async def update_doc_from_module(document: dict[str, Any]) -> dict[str, Any]:
-    from home_index import main as hi
 
     next_module_name = ""
     found_previous_next = False
@@ -205,7 +211,6 @@ def set_next_modules(files_docs_by_hash: dict[str, dict[str, Any]]) -> None:
 
 
 async def run_module(name: str, proxy: ServerProxy) -> bool:
-    from home_index import main as hi
 
     try:
         documents = await hi.get_all_pending_jobs(name)

--- a/features/F4/modules.py
+++ b/features/F4/modules.py
@@ -8,6 +8,7 @@ import os
 import time
 from pathlib import Path
 import importlib
+import sys
 from typing import Any, Mapping, Callable, TypeVar, cast
 from xmlrpc.client import Fault, ServerProxy
 
@@ -109,9 +110,18 @@ def setup_modules() -> tuple[
             version = hello["version"]
             hellos_local.append(hello)
             hello_versions_local.append([name, version])
-            modules_local[name] = {"name": name, "proxy": proxy, "host": module_host}
+            modules_local[name] = {
+                "name": name,
+                "proxy": proxy,
+                "host": module_host,
+            }
             module_values_local.append(modules_local[name])
-    return modules_local, module_values_local, hellos_local, hello_versions_local
+    return (
+        modules_local,
+        module_values_local,
+        hellos_local,
+        hello_versions_local,
+    )
 
 
 def set_global_modules() -> None:
@@ -155,7 +165,11 @@ async def update_doc_from_module(document: dict[str, Any]) -> dict[str, Any]:
     try:
         from home_index import main as hi
     except Exception:  # pragma: no cover - compatibility
-        hi = importlib.import_module("main")
+        hi = sys.modules.get("main")
+        if hi is None:
+            hi = sys.modules.get("__main__")
+        if hi is None:
+            hi = importlib.import_module("main")
     hi = cast(Any, hi)
 
     next_module_name = ""
@@ -213,7 +227,11 @@ async def run_module(name: str, proxy: ServerProxy) -> bool:
     try:
         from home_index import main as hi
     except Exception:  # pragma: no cover - compatibility
-        hi = importlib.import_module("main")
+        hi = sys.modules.get("main")
+        if hi is None:
+            hi = sys.modules.get("__main__")
+        if hi is None:
+            hi = importlib.import_module("main")
     hi = cast(Any, hi)
 
     try:

--- a/main.py
+++ b/main.py
@@ -121,16 +121,16 @@ CPU_COUNT = os.cpu_count() or 1
 MAX_HASH_WORKERS = int(os.environ.get("MAX_HASH_WORKERS", CPU_COUNT // 2))
 MAX_FILE_WORKERS = int(os.environ.get("MAX_FILE_WORKERS", CPU_COUNT // 2))
 
-# embedding configuration
-EMBED_MODEL_NAME = os.environ.get("EMBED_MODEL_NAME", "intfloat/e5-small-v2")
-try:
-    import torch
+from shared import EMBED_MODEL_NAME, EMBED_DEVICE, EMBED_DIM
+from shared.embedding import embed_texts, embedding_model
 
-    default_device = "cuda" if torch.cuda.is_available() else "cpu"
-except Exception:
-    default_device = "cpu"
-EMBED_DEVICE = os.environ.get("EMBED_DEVICE", default_device)
-EMBED_DIM = int(os.environ.get("EMBED_DIM", "384"))
+__all__ = [
+    "embed_texts",
+    "embedding_model",
+    "EMBED_MODEL_NAME",
+    "EMBED_DEVICE",
+    "EMBED_DIM",
+]
 
 INDEX_DIRECTORY = Path(os.environ.get("INDEX_DIRECTORY", "/files"))
 
@@ -162,25 +162,8 @@ _safe_mkdir(ARCHIVE_DIRECTORY)
 RESERVED_FILES_DIRS = [METADATA_DIRECTORY]
 
 
-# embedding model setup
-embedding_model = None
-
-
-def init_embedder():
-    """Initialize the sentence transformer model on first use."""
-    global embedding_model
-    if embedding_model is None:
-        from sentence_transformers import SentenceTransformer
-
-        embedding_model = SentenceTransformer(EMBED_MODEL_NAME, device=EMBED_DEVICE)
-
-
-def embed_texts(texts):
-    """Return embeddings for a list of texts."""
-    if embedding_model is None:
-        init_embedder()
-    vectors = embedding_model.encode(texts, convert_to_numpy=True)
-    return [vec.tolist() for vec in vectors]
+# embedding helpers
+# functions imported from shared
 
 
 def parse_cron_env(

--- a/packages/home_index/__init__.py
+++ b/packages/home_index/__init__.py
@@ -1,1 +1,0 @@
-# Package for home_index

--- a/packages/home_index/__main__.py
+++ b/packages/home_index/__main__.py
@@ -1,5 +1,0 @@
-import asyncio
-from .main import main
-
-if __name__ == "__main__":
-    asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,11 @@ setup(
     author="Nash Spence",
     author_email="nashspence@gmail.com",
     url="https://github.com/nashspence/home-index",
-    packages=["home_index"]
-    + find_namespace_packages(where=".", include=["features*"], exclude=["*.test*"]),
-    package_dir={
-        "": ".",
-        "home_index": "packages/home_index",
-    },
+    py_modules=["main"],
+    packages=find_namespace_packages(
+        where=".", include=["features*"], exclude=["*.test*"]
+    ),
+    package_dir={"": "."},
     install_requires=[
         "apscheduler==3.11.0",
         "debugpy==1.8.14",

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,0 +1,15 @@
+from .embedding import (
+    EMBED_MODEL_NAME,
+    EMBED_DEVICE,
+    EMBED_DIM,
+    init_embedder,
+    embed_texts,
+)
+
+__all__ = [
+    "EMBED_MODEL_NAME",
+    "EMBED_DEVICE",
+    "EMBED_DIM",
+    "init_embedder",
+    "embed_texts",
+]

--- a/shared/embedding.py
+++ b/shared/embedding.py
@@ -1,0 +1,39 @@
+import os
+from typing import List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sentence_transformers import SentenceTransformer
+
+EMBED_MODEL_NAME = os.environ.get("EMBED_MODEL_NAME", "intfloat/e5-small-v2")
+try:
+    import torch
+
+    _default_device = "cuda" if torch.cuda.is_available() else "cpu"
+except Exception:
+    _default_device = "cpu"
+EMBED_DEVICE = os.environ.get("EMBED_DEVICE", _default_device)
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "384"))
+
+_embedding_model: Optional["SentenceTransformer"] = None
+# expose for external patching in tests
+embedding_model = _embedding_model
+
+
+def init_embedder() -> None:
+    """Initialize the sentence transformer model on first use."""
+    global _embedding_model, embedding_model
+    if _embedding_model is None:
+        from sentence_transformers import SentenceTransformer
+
+        _embedding_model = SentenceTransformer(EMBED_MODEL_NAME, device=EMBED_DEVICE)
+        embedding_model = _embedding_model
+
+
+def embed_texts(texts: List[str]) -> List[List[float]]:
+    """Return embeddings for a list of texts."""
+    global embedding_model
+    if embedding_model is None:
+        init_embedder()
+        assert embedding_model is not None
+    vectors = embedding_model.encode(texts, convert_to_numpy=True)
+    return [vec.tolist() for vec in vectors]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import sys
 from pathlib import Path
 
-# Ensure local packages are importable
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packages"))
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import types
 import pytest

--- a/tests/test_archive_support.py
+++ b/tests/test_archive_support.py
@@ -35,7 +35,7 @@ def test_metadata_persists_if_the_archive_directory_is_temporarily_missing(
     monkeypatch.setenv("BY_PATH_DIRECTORY", str(by_path))
     monkeypatch.setenv("ARCHIVE_DIRECTORY", str(archive_dir))
 
-    import home_index.main as hi
+    import main as hi
 
     importlib.reload(hi)
 
@@ -74,7 +74,7 @@ def test_metadata_and_symlinks_are_purged_after_an_archive_file_is_removed(
     monkeypatch.setenv("BY_PATH_DIRECTORY", str(by_path))
     monkeypatch.setenv("ARCHIVE_DIRECTORY", str(archive_dir))
 
-    import home_index.main as hi
+    import main as hi
     import importlib
 
     importlib.reload(hi)

--- a/tests/test_chunk_integration.py
+++ b/tests/test_chunk_integration.py
@@ -4,7 +4,7 @@ import json
 
 def test_run_module_processes_chunk_docs(monkeypatch):
     import importlib
-    import home_index.main as hi
+    import main as hi
 
     importlib.reload(hi)
 
@@ -56,7 +56,7 @@ def test_run_module_processes_chunk_docs(monkeypatch):
 
 def test_run_module_handles_update_only(monkeypatch):
     import importlib
-    import home_index.main as hi
+    import main as hi
 
     importlib.reload(hi)
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,6 +1,6 @@
 def test_embed_texts_uses_provided_model(monkeypatch):
     import importlib
-    import home_index.main as hi
+    import main as hi
 
     importlib.reload(hi)
 
@@ -12,7 +12,9 @@ def test_embed_texts_uses_provided_model(monkeypatch):
         def encode(self, texts, convert_to_numpy=True):
             return [self.Vec([len(t)] * hi.EMBED_DIM) for t in texts]
 
-    hi.embedding_model = DummyModel()
+    import shared.embedding as emb
+
+    emb.embedding_model = DummyModel()
 
     result = hi.embed_texts(["a", "bb"])
 

--- a/tests/test_f4_module_helpers.py
+++ b/tests/test_f4_module_helpers.py
@@ -66,7 +66,7 @@ def test_update_doc_from_module_updates_and_saves(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     modules = _reload_modules(monkeypatch, tmp_path)
-    import home_index.main as hi
+    import main as hi
 
     importlib.reload(hi)
 

--- a/tests/test_metadata_migration.py
+++ b/tests/test_metadata_migration.py
@@ -2,7 +2,7 @@ import importlib
 
 
 def test_migrate_doc_adds_paths_list():
-    import home_index.main as hi
+    import main as hi
 
     importlib.reload(hi)
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -10,7 +10,7 @@ def test_cron_schedules_are_parsed_from_the_environment(monkeypatch, tmp_path):
     index_dir.mkdir()
     monkeypatch.setenv("INDEX_DIRECTORY", str(index_dir))
     monkeypatch.setenv("CRON_EXPRESSION", "15 2 * * 3")
-    import home_index.main as hi
+    import main as hi
     import importlib
 
     importlib.reload(hi)
@@ -30,7 +30,7 @@ def test_malformed_cron_expressions_raise_valueerror(monkeypatch, tmp_path):
     monkeypatch.setenv("LOGGING_DIRECTORY", str(log_dir))
     monkeypatch.setenv("MODULES", "")
     monkeypatch.setenv("CRON_EXPRESSION", "15 2 * *")
-    import home_index.main as hi
+    import main as hi
     import importlib
 
     importlib.reload(hi)
@@ -62,7 +62,7 @@ def test_scheduler_attaches_a_crontrigger_job_for_periodic_indexing(
         def start(self):
             added["started"] = True
 
-    import home_index.main as hi
+    import main as hi
     import importlib
 
     importlib.reload(hi)

--- a/tests/test_update_meilisearch.py
+++ b/tests/test_update_meilisearch.py
@@ -3,7 +3,7 @@ import asyncio
 
 def test_update_meilisearch_adds_and_deletes_documents(monkeypatch):
     import importlib
-    import home_index.main as hi
+    import main as hi
 
     importlib.reload(hi)
 


### PR DESCRIPTION
## Summary
- drop `packages/home_index` compatibility package
- update Dockerfile entry to run `main.py`
- adjust VS Code launch configuration
- update setup.py to use `main` module
- strip example module from docker-compose and fix tests

## Testing
- `./agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685f02e55334832bbca0803a41037ac0