### PR TITLE
Update VS Code tasks for acceptance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,39 @@
             ],
             "preLaunchTask": "Restart Docker Container",
             "postDebugTask": "Stop Docker Compose"
+        },
+        {
+            "name": "Run Acceptance Script",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/run_acceptance.py",
+            "console": "integratedTerminal",
+            "env": {
+                "DEBUG": "True",
+                "WAIT_FOR_DEBUGPY_CLIENT": "True"
+            }
+        },
+        {
+            "name": "Attach Release Container",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/app"
+                }
+            ]
+        }
+    ]
+    ,
+    "compounds": [
+        {
+            "name": "Run Acceptance",
+            "configurations": ["Run Acceptance Script", "Attach Release Container"]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,19 @@
             "presentation": {
                 "reveal": "always"
             }
+        },
+        {
+            "label": "Run Acceptance",
+            "type": "shell",
+            "command": "bash",
+            "args": [
+                "-c",
+                "DEBUG=True WAIT_FOR_DEBUGPY_CLIENT=True python run_acceptance.py"
+            ],
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "always"
+            }
         }
     ]
 }

--- a/features/F1/test/docker-compose.yml
+++ b/features/F1/test/docker-compose.yml
@@ -4,9 +4,15 @@ services:
     environment:
       - CRON_EXPRESSION=${CRON_EXPRESSION}
       - METADATA_DIRECTORY=/home-index/metadata
+      - DEBUG=${DEBUG:-False}
+      - DEBUGPY_HOST=${DEBUGPY_HOST:-0.0.0.0}
+      - DEBUGPY_PORT=${DEBUGPY_PORT:-5678}
+      - WAIT_FOR_DEBUGPY_CLIENT=${WAIT_FOR_DEBUGPY_CLIENT:-False}
     volumes:
       - ./input:/files:ro
       - ./output:/home-index
+    ports:
+      - "5678:5678"
     depends_on:
       - meilisearch
   meilisearch:

--- a/features/F2/test/docker-compose.yml
+++ b/features/F2/test/docker-compose.yml
@@ -3,9 +3,15 @@ services:
     image: ${IMAGE}
     environment:
       - METADATA_DIRECTORY=/home-index/metadata
+      - DEBUG=${DEBUG:-False}
+      - DEBUGPY_HOST=${DEBUGPY_HOST:-0.0.0.0}
+      - DEBUGPY_PORT=${DEBUGPY_PORT:-5678}
+      - WAIT_FOR_DEBUGPY_CLIENT=${WAIT_FOR_DEBUGPY_CLIENT:-False}
     volumes:
       - ./input:/files:ro
       - ./output:/home-index
+    ports:
+      - "5678:5678"
     depends_on:
       - meilisearch
   meilisearch:

--- a/features/F3/test/docker-compose.yml
+++ b/features/F3/test/docker-compose.yml
@@ -3,9 +3,15 @@ services:
     image: ${IMAGE}
     environment:
       - METADATA_DIRECTORY=/home-index/metadata
+      - DEBUG=${DEBUG:-False}
+      - DEBUGPY_HOST=${DEBUGPY_HOST:-0.0.0.0}
+      - DEBUGPY_PORT=${DEBUGPY_PORT:-5678}
+      - WAIT_FOR_DEBUGPY_CLIENT=${WAIT_FOR_DEBUGPY_CLIENT:-False}
     volumes:
       - ./input:/files:ro
       - ./output:/home-index
+    ports:
+      - "5678:5678"
     depends_on:
       - meilisearch
   meilisearch:

--- a/features/F4/test/docker-compose.yml
+++ b/features/F4/test/docker-compose.yml
@@ -5,9 +5,15 @@ services:
       - METADATA_DIRECTORY=/home-index/metadata
       - MODULES=http://example-module:9000
       - RETRY_UNTIL_READY_SECONDS=180
+      - DEBUG=${DEBUG:-False}
+      - DEBUGPY_HOST=${DEBUGPY_HOST:-0.0.0.0}
+      - DEBUGPY_PORT=${DEBUGPY_PORT:-5678}
+      - WAIT_FOR_DEBUGPY_CLIENT=${WAIT_FOR_DEBUGPY_CLIENT:-False}
     volumes:
       - ./input:/files:ro
       - ./output:/home-index
+    ports:
+      - "5678:5678"
     depends_on:
       - meilisearch
       - example-module

--- a/run_acceptance.py
+++ b/run_acceptance.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+from pathlib import Path
+
+root = Path(__file__).resolve().parent
+os.chdir(root)
+
+repo = root.name
+sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+image = f"{repo}:ci"
+
+subprocess.run(["./check.sh"], check=True)
+subprocess.run(["docker", "build", "-f", "Dockerfile", "-t", image, "."], check=True)
+
+env = os.environ.copy()
+env["IMAGE"] = image
+env["HOME_INDEX_REF"] = sha
+env.setdefault("DEBUG", "False")
+env.setdefault("WAIT_FOR_DEBUGPY_CLIENT", "False")
+env.setdefault("DEBUGPY_HOST", "0.0.0.0")
+env.setdefault("DEBUGPY_PORT", "5678")
+
+for feature in sorted(Path("features").glob("F*/test/acceptance.py")):
+    subprocess.run(["pytest", "-q", str(feature)], env=env, check=True)


### PR DESCRIPTION
## Summary
- allow running acceptance tests from VS Code UI
- debug config attaches to release containers
- port 5678 exposed in feature test compose files
- add default debug envs to acceptance helper script

## Testing
- `./agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685f2380873c832ba6ac299400c309d0