### PR TITLE
Remove unused ML deps from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,26 +11,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-# ── *Optional* CUDA user-space install (skipped when CUDA_MAJOR=0) ──────────
-ARG CUDA_MAJOR=0
-ARG CUDA_MINOR=0
-ARG CUDA_PKG
-RUN set -eux; \
-    if [ "${CUDA_MAJOR}" != "0" ]; then \
-        CUDA_PKG="${CUDA_PKG:-${CUDA_MAJOR}-${CUDA_MINOR}}"; \
-        UBUNTU_REL=$(lsb_release -sr | tr -d .); \
-        curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_REL}/x86_64/cuda-ubuntu${UBUNTU_REL}.pin \
-          -o /etc/apt/preferences.d/cuda-repository-pin-600; \
-        curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_REL}/x86_64/3bf863cc.pub | \
-          gpg --dearmor -o /usr/share/keyrings/cuda.gpg; \
-        echo "deb [signed-by=/usr/share/keyrings/cuda.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_REL}/x86_64/ /" \
-          > /etc/apt/sources.list.d/cuda.list; \
-        apt-get update; \
-        apt-get install -y --no-install-recommends \
-            cuda-toolkit-${CUDA_PKG} \
-            cuda-compat-${CUDA_PKG}; \
-        rm -rf /var/lib/apt/lists/*; \
-    fi
 
 ENV PIP_ROOT_USER_ACTION=ignore
 
@@ -41,15 +21,7 @@ RUN pip install --no-cache-dir --disable-pip-version-check \
     debugpy==1.8.14 \
     meilisearch-python-sdk==4.7.1 \
     python-magic==0.4.27 \
-    xxhash==3.5.0 \
-    sentence-transformers==4.1.0 \
-    transformers==4.52.4
-RUN python - <<'EOF'
-from transformers import AutoTokenizer
-from sentence_transformers import SentenceTransformer
-AutoTokenizer.from_pretrained("intfloat/e5-small-v2")
-SentenceTransformer("intfloat/e5-small-v2")
-EOF
+    xxhash==3.5.0
 
 COPY main.py ./
 COPY shared ./shared

--- a/README.md
+++ b/README.md
@@ -31,4 +31,3 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
 - Expand acceptance tests to cover all features (F5 concept search improved).
 - Rewrite remaining feature docs to conform to AGENTS.md.
-- Audit Dockerfiles for any remaining unused dependencies.


### PR DESCRIPTION
## Summary
- remove CUDA and transformers packages from the release Dockerfile
- update Planned_Maintenance list in README

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861c60ddc64832bb34d5c2c86d4bbc1