### PR TITLE
Refactor acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,7 @@ your files using a locally run language model backed by Meilisearch.
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
+## Planned Maintenance
+
 - Expand acceptance tests to cover all features (F5 concept search improved).
 - Rewrite remaining feature docs to conform to AGENTS.md.

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -5,6 +5,7 @@ from .embedding import (
     init_embedder,
     embed_texts,
 )
+from .acceptance import compose, dump_logs, search_meili, search_chunks, wait_for
 
 __all__ = [
     "EMBED_MODEL_NAME",
@@ -12,4 +13,9 @@ __all__ = [
     "EMBED_DIM",
     "init_embedder",
     "embed_texts",
+    "dump_logs",
+    "search_meili",
+    "search_chunks",
+    "compose",
+    "wait_for",
 ]

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+def dump_logs(compose_file: Path, workdir: Path) -> None:
+    """Print logs from all compose containers."""
+    subprocess.run(
+        ["docker", "compose", "-f", str(compose_file), "logs", "--no-color"],
+        cwd=workdir,
+        check=False,
+    )
+    sys.stdout.flush()
+
+
+def search_meili(
+    compose_file: Path,
+    workdir: Path,
+    filter_expr: str,
+    *,
+    timeout: int = 120,
+    q: str = "",
+    index: str = "files",
+) -> list[dict[str, Any]]:
+    """Return documents matching ``filter_expr`` from Meilisearch."""
+    deadline = time.time() + timeout
+    url = f"http://localhost:7700/indexes/{index}/search"
+    while True:
+        try:
+            data = {"q": q, "filter": filter_expr}
+            req = urllib.request.Request(
+                url,
+                data=json.dumps(data).encode(),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req) as resp:
+                payload = json.load(resp)
+            docs = payload.get("hits") or payload.get("results") or []
+            if docs:
+                return list(docs)
+        except Exception:
+            pass
+        if time.time() > deadline:
+            raise AssertionError(
+                f"Timed out waiting for search results for: {filter_expr}"
+            )
+        time.sleep(0.5)
+
+
+def search_chunks(
+    query: str,
+    *,
+    filter_expr: str = "",
+    timeout: int = 300,
+) -> list[dict[str, Any]]:
+    """Return chunk documents matching ``query`` from Meilisearch."""
+    deadline = time.time() + timeout
+    url = "http://localhost:7700/indexes/file_chunks/search"
+    while True:
+        try:
+            data = {
+                "q": f"query: {query}",
+                "hybrid": {"semanticRatio": 1, "embedder": "e5-small"},
+            }
+            if filter_expr:
+                data["filter"] = filter_expr
+            req = urllib.request.Request(
+                url,
+                data=json.dumps(data).encode(),
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req) as resp:
+                payload = json.load(resp)
+            docs = payload.get("hits") or payload.get("results") or []
+            if docs:
+                return list(docs)
+        except Exception:
+            pass
+        if time.time() > deadline:
+            raise AssertionError("Timed out waiting for search results")
+        time.sleep(0.5)
+
+
+def compose(
+    compose_file: Path,
+    workdir: Path,
+    *args: str,
+    env_file: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    """Run ``docker compose`` with the given arguments."""
+    cmd = ["docker", "compose"]
+    if env_file:
+        cmd += ["--env-file", str(env_file)]
+    cmd += ["-f", str(compose_file), *args]
+    return subprocess.run(cmd, check=check, cwd=workdir)
+
+
+def wait_for(
+    predicate: Callable[[], bool],
+    *,
+    timeout: int = 120,
+    interval: float = 0.5,
+    message: str = "condition",
+) -> None:
+    """Wait until ``predicate`` is true or raise ``AssertionError``."""
+    deadline = time.time() + timeout
+    while True:
+        if predicate():
+            return
+        if time.time() > deadline:
+            raise AssertionError(f"Timed out waiting for {message}")
+        time.sleep(interval)


### PR DESCRIPTION
## Summary
- share acceptance test helpers in `shared/acceptance.py`
- use new helpers across F2–F5 tests
- document Planned Maintenance section
- remove unused imports and fix README heading

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6861de907220832ba3d069f53aac196c