### PR TITLE
Fix concept search doc output

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,3 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Planned Maintenance
 
-- Expand acceptance tests to cover all features (F5 concept search improved).

--- a/docs/F5.md
+++ b/docs/F5.md
@@ -105,6 +105,10 @@ the chunk documents. The search response includes the same chunk ID.
 
 The `search_chunks` helper automatically prefixes the query with `"query: "`,
 but when sending requests manually you must include this prefix yourself.
+Concept search also matches synonyms, e.g. querying for "automatic learning from
+data" returns passages about "algorithms that learn from data".
+The `file_chunks` index exposes `file_id` and `module` as filterable attributes
+and `index` as sortable, so you can paginate results in document order.
 
 ---
 
@@ -119,5 +123,6 @@ but when sending requests manually you must include this prefix yourself.
 ## Acceptance
 
 1. After indexing completes, a `chunks.json` file exists under `./output/metadata/by-id/<file-hash>/chunk_module/`.
-2. Querying the `file_chunks` index with a *different phrase* that expresses the same concept returns the chunk document when filtered by `file_id`.
-3. The chunk document includes `id`, `file_id`, `module`, and `text` fields.
+2. Querying the `file_chunks` index with a *different phrase* that expresses the same concept returns the chunk document when filtered by `file_id` or `module`.
+3. The chunk document includes `id`, `file_id`, `module`, `index`, and `text` fields.
+4. The `file_chunks` index allows sorting by the `index` field.

--- a/docs/meilisearch_file_chunk.schema.json
+++ b/docs/meilisearch_file_chunk.schema.json
@@ -20,6 +20,10 @@
       "type": "string",
       "description": "Name of the module that produced the chunk"
     },
+    "index": {
+      "type": "integer",
+      "description": "Position of the chunk within the module's context"
+    },
     "start": {
       "type": "number",
       "description": "Optional start offset of the chunk in the source (float)"
@@ -34,6 +38,6 @@
       "description": "Sentence embedding vector for semantic search"
     }
   },
-  "required": ["id", "file_id", "module", "text"],
+  "required": ["id", "file_id", "module", "text", "index"],
   "additionalProperties": true
 }

--- a/docs/sample_chunk_document.json
+++ b/docs/sample_chunk_document.json
@@ -2,5 +2,6 @@
   "id": "example_chunk",
   "file_id": "example-file",
   "module": "pretend",
+  "index": 0,
   "text": "sample text"
 }

--- a/features/F5/chunk_utils.py
+++ b/features/F5/chunk_utils.py
@@ -35,6 +35,8 @@ def segments_to_chunk_docs(
         doc = seg_doc.copy()
         doc.setdefault("id", f"{module_name}_{file_id}_{idx}")
         doc.setdefault("file_id", file_id)
+        doc.setdefault("module", module_name)
+        doc["index"] = idx
         doc["text"] = text
 
         docs.append(doc)

--- a/main.py
+++ b/main.py
@@ -265,8 +265,11 @@ async def init_meili():
             raise RuntimeError("embedder not stored")
 
         # 3️⃣ set filterable attributes
-        files_logger.info("update chunk index filterable attributes")
-        settings_body = MeilisearchSettings(filterable_attributes=["file_id"])
+        files_logger.info("update chunk index settings")
+        settings_body = MeilisearchSettings(
+            filterable_attributes=["file_id", "module"],
+            sortable_attributes=["index"],
+        )
         task = await chunk_index.update_settings(settings_body)
         await client.wait_for_task(task.task_uid)
     except Exception:

--- a/tests/test_chunk_utils.py
+++ b/tests/test_chunk_utils.py
@@ -9,9 +9,11 @@ def test_segments_with_headers_convert_to_chunk_documents_referencing_the_source
     docs = segments_to_chunk_docs(segments, "file1", module_name="mod")
     assert docs[0]["id"] == "mod_file1_0"
     assert docs[0]["file_id"] == "file1"
+    assert docs[0]["index"] == 0
     assert docs[0]["text"].startswith("[speaker: A]\n")
     assert docs[1]["id"] == "mod_file1_1"
     assert docs[1]["file_id"] == "file1"
+    assert docs[1]["index"] == 1
 
 
 def test_tokentextsplitter_divides_chunk_text_into_smaller_documents():


### PR DESCRIPTION
## Summary
- persist module name in chunk docs
- clarify F5 documentation about synonym matches
- include index in each chunk document
- configure chunk index filterable/sortable fields

## Testing
- `./agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6861eb798d68832bbbfe7cecb8b03ec9