### PR TITLE
Improve F4 queue protocol tests

### DIFF
--- a/docs/F4.md
+++ b/docs/F4.md
@@ -101,7 +101,8 @@ After the sync finishes a folder named after the module appears under `output/me
 
 ## Acceptance
 
-1. Each configured module runs when at least one file path is online and processes tasks from its Redis queue.
-2. Module artifacts appear under `./output/metadata/by-id/<file-hash>/<module>/` after processing.
-3. `modules_config.json` records the module configuration so subsequent runs skip unchanged modules.
+1. Each configured module consumes jobs from `<name>:check` then `<name>:run` queues whenever at least one file path is online.
+2. Check and run jobs that exceed the `TIMEOUT` value are requeued and retried until they complete.
+3. Module artifacts appear under `./output/metadata/by-id/<file-hash>/<module>/` after successful processing.
+4. `modules_config.json` records the module configuration so subsequent runs skip unchanged modules.
 

--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -3,6 +3,8 @@ import os
 import shutil
 from pathlib import Path
 
+import subprocess
+
 from shared import compose, dump_logs, search_meili, wait_for
 
 from features.F2 import duplicate_finder
@@ -60,3 +62,150 @@ def test_modules_process_documents(tmp_path: Path) -> None:
     output_dir = workdir / "output"
     env_file = tmp_path / ".env"
     _run_once(compose_file, workdir, output_dir, env_file)
+
+
+def _redis_llen(compose_file: Path, workdir: Path, key: str) -> int:
+    output = subprocess.check_output(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(compose_file),
+            "exec",
+            "-T",
+            "redis",
+            "redis-cli",
+            "LLEN",
+            key,
+        ],
+        cwd=workdir,
+    )
+    return int(output.decode().strip())
+
+
+def _run_timeout(
+    compose_file: Path, workdir: Path, output_dir: Path, env_file: Path
+) -> None:
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+    (output_dir / "modules_config.json").write_text(
+        '{"modules": [{"name": "timeout-module"}]}'
+    )
+
+    env_file.write_text(
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=2\n"
+    )
+
+    compose(compose_file, workdir, "up", "-d", env_file=env_file)
+
+    doc_path = workdir / "input" / "hello.txt"
+    doc_id = duplicate_finder.compute_hash(doc_path)
+    log_file = output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "log.txt"
+    wait_for(log_file.exists, timeout=120, message="timeout log")
+    # allow the job to time out
+    wait_for(
+        lambda: _redis_llen(compose_file, workdir, "modules:done") == 0,
+        timeout=60,
+        message="no done",
+    )
+
+    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+
+    env_file.write_text(
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=0\n"
+    )
+    compose(compose_file, workdir, "up", "-d", env_file=env_file)
+
+    version_file = (
+        output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "version.json"
+    )
+    wait_for(version_file.exists, timeout=300, message="module output")
+    logs = log_file.read_text().splitlines()
+    assert sum(1 for line in logs if "start" in line) >= 2
+    docs = search_meili(compose_file, workdir, f'id = "{doc_id}"', timeout=300)
+    assert any(doc["id"] == doc_id for doc in docs)
+
+    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+    compose(
+        compose_file,
+        workdir,
+        "down",
+        "--volumes",
+        "--rmi",
+        "local",
+        env_file=env_file,
+        check=False,
+    )
+
+
+def _run_check_timeout(
+    compose_file: Path, workdir: Path, output_dir: Path, env_file: Path
+) -> None:
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+    (output_dir / "modules_config.json").write_text(
+        '{"modules": [{"name": "timeout-module"}]}'
+    )
+
+    env_file.write_text(
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=2\nMODULE_SLEEP=0\n"
+    )
+
+    compose(compose_file, workdir, "up", "-d", env_file=env_file)
+
+    doc_path = workdir / "input" / "hello.txt"
+    doc_id = duplicate_finder.compute_hash(doc_path)
+
+    wait_for(
+        lambda: _redis_llen(compose_file, workdir, "timeout-module:check:processing")
+        > 0,
+        timeout=60,
+        message="processing",
+    )
+    wait_for(
+        lambda: _redis_llen(compose_file, workdir, "timeout-module:check") == 1,
+        timeout=120,
+        message="requeued",
+    )
+
+    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+
+    env_file.write_text(
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=0\nMODULE_SLEEP=0\n"
+    )
+    compose(compose_file, workdir, "up", "-d", env_file=env_file)
+
+    version_file = (
+        output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "version.json"
+    )
+    wait_for(version_file.exists, timeout=300, message="module output")
+
+    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+    compose(
+        compose_file,
+        workdir,
+        "down",
+        "--volumes",
+        "--rmi",
+        "local",
+        env_file=env_file,
+        check=False,
+    )
+
+
+def test_module_timeouts(tmp_path: Path) -> None:
+    compose_file = Path(__file__).with_name("docker-compose.yml")
+    workdir = compose_file.parent
+    output_dir = workdir / "output"
+    env_file = tmp_path / ".env"
+    _run_timeout(compose_file, workdir, output_dir, env_file)
+
+
+def test_module_check_timeouts(tmp_path: Path) -> None:
+    compose_file = Path(__file__).with_name("docker-compose.yml")
+    workdir = compose_file.parent
+    output_dir = workdir / "output"
+    env_file = tmp_path / ".env"
+    _run_check_timeout(compose_file, workdir, output_dir, env_file)

--- a/features/F4/test/docker-compose.yml
+++ b/features/F4/test/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     environment:
       MODULES: |
         - name: example-module
+        - name: timeout-module
       METADATA_DIRECTORY: /home-index/metadata
       REDIS_HOST: http://redis:6379
       RETRY_UNTIL_READY_SECONDS: 180
@@ -19,6 +20,7 @@ services:
     depends_on:
       - meilisearch
       - example-module
+      - timeout-module
       - redis
   meilisearch:
     image: getmeili/meilisearch:v1.15
@@ -39,7 +41,25 @@ services:
       - METADATA_DIRECTORY=/home-index/metadata
       - QUEUE_NAME=example-module
       - REDIS_HOST=http://redis:6379
-      - TIMEOUT=300
+      - TIMEOUT=${EXAMPLE_TIMEOUT:-300}
+      - SLEEP=${EXAMPLE_SLEEP:-0}
+      - CHECK_SLEEP=${EXAMPLE_CHECK_SLEEP:-0}
+    volumes:
+      - ./input:/files:ro
+      - ./output:/home-index
+  timeout-module:
+    build:
+      context: ./timeout_module/
+      dockerfile: Dockerfile
+      args:
+        BASE_IMAGE: ${MODULE_BASE_IMAGE}
+    environment:
+      - METADATA_DIRECTORY=/home-index/metadata
+      - QUEUE_NAME=timeout-module
+      - REDIS_HOST=http://redis:6379
+      - TIMEOUT=${TIMEOUT:-300}
+      - SLEEP=${MODULE_SLEEP:-0}
+      - CHECK_SLEEP=${CHECK_SLEEP:-0}
     volumes:
       - ./input:/files:ro
       - ./output:/home-index

--- a/features/F4/test/timeout_module/Dockerfile
+++ b/features/F4/test/timeout_module/Dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+WORKDIR /app
+COPY main.py .
+ENTRYPOINT ["python3", "/app/main.py"]
+

--- a/features/F4/test/timeout_module/main.py
+++ b/features/F4/test/timeout_module/main.py
@@ -1,0 +1,47 @@
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+from features.F4.home_index_module import run_server
+
+VERSION = 1
+NAME = os.environ.get("NAME", "example_module")
+QUEUE_NAME = os.environ.get("QUEUE_NAME", NAME)
+TIMEOUT = int(os.environ.get("TIMEOUT", "300"))
+CHECK_SLEEP = float(os.environ.get("CHECK_SLEEP", "0"))
+
+
+def check(
+    file_path: Path, document: Mapping[str, Any], metadata_dir_path: Path
+) -> bool:
+    """Return True if the document should be processed."""
+    if CHECK_SLEEP:
+        time.sleep(CHECK_SLEEP)
+    version_path = metadata_dir_path / "version.json"
+    if not version_path.exists():
+        return True
+    with open(version_path) as file:
+        version = cast(dict[str, Any], json.load(file))
+    return int(version["version"]) != VERSION
+
+
+def run(
+    file_path: Path, document: Mapping[str, Any], metadata_dir_path: Path
+) -> Mapping[str, Any]:
+    """Process a document and return the updated version."""
+    logging.info("start %s", file_path)
+    sleep = float(os.environ.get("SLEEP", "0"))
+    if sleep:
+        time.sleep(sleep)
+    version_path = metadata_dir_path / "version.json"
+    with open(version_path, "w") as file:
+        json.dump({"version": VERSION}, file, indent=4)
+    logging.info("done")
+    return document
+
+
+if __name__ == "__main__":
+    run_server(check, run)


### PR DESCRIPTION
## Summary
- test F4 modules with timeout and requeue logic
- exercise redis queues via docker-compose exec
- document stricter acceptance requirements
- cover check timeouts and run timeouts

## Testing
- `./agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68667de812e4832bb6b5ad8767955f04