### PR TITLE
Fix module timeout race

### DIFF
--- a/features/F4/home_index_module/run_server.py
+++ b/features/F4/home_index_module/run_server.py
@@ -303,6 +303,8 @@ def run_server(
         file_path = file_path_from_meili_doc(document)
         metadata_dir_path = metadata_dir_path_from_doc(document)
         should_run = check_fn(file_path, document, metadata_dir_path)
+        if should_run:
+            (metadata_dir_path / "log.txt").touch(exist_ok=True)
         key = json.dumps({"q": f"{QUEUE_NAME}:check", "d": doc_json})
         expiration = client.zscore(TIMEOUT_SET, key)
         removed = remove_timeout(f"{QUEUE_NAME}:check", doc_json)

--- a/features/F4/home_index_module/run_server.py
+++ b/features/F4/home_index_module/run_server.py
@@ -307,10 +307,10 @@ def run_server(
             (metadata_dir_path / "log.txt").touch(exist_ok=True)
         key = json.dumps({"q": f"{QUEUE_NAME}:check", "d": doc_json})
         expiration = client.zscore(TIMEOUT_SET, key)
+        if expiration is not None and time.time() > float(expiration):
+            return True
         removed = remove_timeout(f"{QUEUE_NAME}:check", doc_json)
         if not removed:
-            return True
-        if expiration is not None and time.time() > float(expiration):
             return True
         if should_run:
             client.rpush(f"{QUEUE_NAME}:run", doc_json)
@@ -347,10 +347,10 @@ def run_server(
         with log_to_file_and_stdout(metadata_dir_path / "log.txt"):
             result = run_fn(file_path, document, metadata_dir_path)
         expiration = client.zscore(TIMEOUT_SET, key)
+        if expiration is not None and time.time() > float(expiration):
+            return True
         removed = remove_timeout(f"{QUEUE_NAME}:run", doc_json)
         if not removed:
-            return True
-        if expiration is not None and time.time() > float(expiration):
             return True
         for group in RESOURCE_SHARE_GROUPS:
             client.zadd(


### PR DESCRIPTION
## Summary
- fix race where timed-out module jobs could still push DONE queue
- handle missing timeout for module check stage

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875c33a7ec4832ba5634c0df9565a6b