### PR TITLE
Enable strict typing for F5

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -21,5 +21,6 @@ mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packag
 mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F2
 mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F3
 mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F4
+mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F5
 mypy --ignore-missing-imports --strict --explicit-package-bases --no-site-packages features/F6
 pytest -q

--- a/features/F5/chunk_utils.py
+++ b/features/F5/chunk_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, cast
 
 
 EMBED_MODEL_NAME = os.environ.get("EMBED_MODEL_NAME", "intfloat/e5-small-v2")
@@ -176,7 +176,10 @@ def load_chunk_settings() -> dict[str, Any] | None:
     if not CHUNK_SETTINGS_FILE_PATH.exists():
         return None
     with CHUNK_SETTINGS_FILE_PATH.open("r") as file:
-        return json.load(file)
+        data = json.load(file)
+    if not isinstance(data, dict):
+        return None
+    return cast(dict[str, Any], data)
 
 
 def save_chunk_settings() -> None:


### PR DESCRIPTION
## Summary
- enforce mypy --strict on F5 modules
- ensure `load_chunk_settings` returns a typed dict

## Testing
- `bash agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875dc949aa8832b8a43fbbf6991a4cc