### PR TITLE
Stabilize F4 timeout tests

### DIFF
--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 
 import subprocess
+import time
 
 from shared import compose, dump_logs, search_meili, wait_for
 from features.F2 import duplicate_finder
@@ -119,11 +120,7 @@ def _run_timeout(
         timeout=120,
         message="requeued",
     )
-    wait_for(
-        lambda: log_file.read_text().count("start") >= 1,
-        timeout=60,
-        message="first start",
-    )
+    time.sleep(2)
     # allow the job to time out
     wait_for(
         lambda: _redis_llen(compose_file, workdir, "modules:done") == 0,

--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -101,7 +101,7 @@ def _run_timeout(
     )
 
     env_file.write_text(
-        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=5\n"
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=2\n"
     )
 
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
@@ -113,6 +113,11 @@ def _run_timeout(
         lambda: _redis_llen(compose_file, workdir, "timeout-module:run:processing") > 0,
         timeout=60,
         message="module started",
+    )
+    wait_for(
+        lambda: _redis_llen(compose_file, workdir, "timeout-module:run") == 1,
+        timeout=120,
+        message="requeued",
     )
     # allow the job to time out
     wait_for(
@@ -161,7 +166,7 @@ def _run_check_timeout(
     )
 
     env_file.write_text(
-        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=5\nMODULE_SLEEP=0\n"
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=2\nMODULE_SLEEP=0\n"
     )
 
     compose(compose_file, workdir, "up", "-d", env_file=env_file)

--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -4,7 +4,6 @@ import shutil
 from pathlib import Path
 
 import subprocess
-import time
 
 from shared import compose, dump_logs, search_meili, wait_for
 from features.F2 import duplicate_finder
@@ -120,7 +119,6 @@ def _run_timeout(
         timeout=120,
         message="requeued",
     )
-    time.sleep(2)
     # allow the job to time out
     wait_for(
         lambda: _redis_llen(compose_file, workdir, "modules:done") == 0,
@@ -128,7 +126,17 @@ def _run_timeout(
         message="no done",
     )
 
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+    compose(
+        compose_file,
+        workdir,
+        "stop",
+        "home-index",
+        "example-module",
+        "timeout-module",
+        "meilisearch",
+        env_file=env_file,
+        check=False,
+    )
 
     env_file.write_text(
         f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=0\n"
@@ -144,7 +152,17 @@ def _run_timeout(
     docs = search_meili(compose_file, workdir, f'id = "{doc_id}"', timeout=300)
     assert any(doc["id"] == doc_id for doc in docs)
 
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+    compose(
+        compose_file,
+        workdir,
+        "stop",
+        "home-index",
+        "example-module",
+        "timeout-module",
+        "meilisearch",
+        env_file=env_file,
+        check=False,
+    )
     compose(
         compose_file,
         workdir,
@@ -187,7 +205,17 @@ def _run_check_timeout(
         message="requeued",
     )
 
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+    compose(
+        compose_file,
+        workdir,
+        "stop",
+        "home-index",
+        "example-module",
+        "timeout-module",
+        "meilisearch",
+        env_file=env_file,
+        check=False,
+    )
 
     env_file.write_text(
         f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=0\nMODULE_SLEEP=0\n"

--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -101,7 +101,7 @@ def _run_timeout(
     )
 
     env_file.write_text(
-        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=2\n"
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=5\n"
     )
 
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
@@ -156,7 +156,7 @@ def _run_check_timeout(
     )
 
     env_file.write_text(
-        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=2\nMODULE_SLEEP=0\n"
+        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=5\nMODULE_SLEEP=0\n"
     )
 
     compose(compose_file, workdir, "up", "-d", env_file=env_file)

--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -119,6 +119,11 @@ def _run_timeout(
         timeout=120,
         message="requeued",
     )
+    wait_for(
+        lambda: log_file.read_text().count("start") >= 1,
+        timeout=60,
+        message="first start",
+    )
     # allow the job to time out
     wait_for(
         lambda: _redis_llen(compose_file, workdir, "modules:done") == 0,

--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -110,7 +110,7 @@ def _run_timeout(
     log_file = output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "log.txt"
     wait_for(log_file.exists, timeout=120, message="timeout log")
     wait_for(
-        lambda: "start" in log_file.read_text(),
+        lambda: _redis_llen(compose_file, workdir, "timeout-module:run:processing") > 0,
         timeout=60,
         message="module started",
     )

--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -109,6 +109,11 @@ def _run_timeout(
     doc_id = _get_doc_id(workdir, output_dir)
     log_file = output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "log.txt"
     wait_for(log_file.exists, timeout=120, message="timeout log")
+    wait_for(
+        lambda: "start" in log_file.read_text(),
+        timeout=60,
+        message="module started",
+    )
     # allow the job to time out
     wait_for(
         lambda: _redis_llen(compose_file, workdir, "modules:done") == 0,


### PR DESCRIPTION
## Summary
- make timeout-module sleep longer in F4 tests
- extend check-phase sleep in F4 tests

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875e2789cb0832b9b573e3ebe8f8c40