### PR TITLE
Expand F3 archive scenarios

### DIFF
--- a/features/F3/archive.py
+++ b/features/F3/archive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping
 
@@ -10,6 +11,9 @@ __all__ = [
     "is_in_archive_dir",
     "doc_is_online",
     "update_archive_flags",
+    "is_status_marker",
+    "drive_name_from_path",
+    "update_drive_markers",
 ]
 
 
@@ -45,3 +49,73 @@ def update_archive_flags(doc: MutableMapping[str, Any]) -> None:
         for relpath in doc.get("paths", {}).keys()
     )
     doc["offline"] = not doc_is_online(doc)
+
+
+STATUS_READY_SUFFIX = "-status-ready"
+STATUS_PENDING_SUFFIX = "-status-pending"
+
+
+def is_status_marker(path: Path) -> bool:
+    """Return True if ``path`` is an archive status marker."""
+    return path.parent == archive_directory() and (
+        path.name.endswith(STATUS_READY_SUFFIX)
+        or path.name.endswith(STATUS_PENDING_SUFFIX)
+    )
+
+
+def drive_name_from_path(path: Path) -> str | None:
+    """Return the archive drive name for ``path`` or ``None``."""
+    try:
+        relative = path.relative_to(archive_directory())
+    except ValueError:
+        return None
+    if relative.parts:
+        return relative.parts[0]
+    return None
+
+
+def _marker_path(drive: str, pending: bool) -> Path:
+    suffix = STATUS_PENDING_SUFFIX if pending else STATUS_READY_SUFFIX
+    return archive_directory() / f"{drive}{suffix}"
+
+
+def update_drive_markers(docs: Mapping[str, Mapping[str, Any]]) -> None:
+    """Update drive status marker files based on ``docs``.
+
+    Markers are updated for all referenced drives. Offline drives retain their
+    timestamp unless work is queued for them (e.g. after a module update).
+    """
+    drives_present = {d.name for d in archive_directory().iterdir() if d.is_dir()}
+    drives_referenced: set[str] = set()
+    pending_map: dict[str, bool] = {}
+    for doc in docs.values():
+        for relpath in doc.get("paths", {}).keys():
+            path = path_from_relpath(relpath)
+            drive = drive_name_from_path(path)
+            if not drive:
+                continue
+            drives_referenced.add(drive)
+            if doc.get("next"):
+                pending_map[drive] = True
+
+    for marker in archive_directory().iterdir():
+        if is_status_marker(marker):
+            name = marker.name
+            if name.endswith(STATUS_READY_SUFFIX):
+                drive = name[: -len(STATUS_READY_SUFFIX)]
+            elif name.endswith(STATUS_PENDING_SUFFIX):
+                drive = name[: -len(STATUS_PENDING_SUFFIX)]
+            else:
+                continue
+            if drive not in drives_referenced:
+                marker.unlink()
+
+    timestamp = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    for drive in drives_referenced:
+        pending = pending_map.get(drive, False)
+        if drive in drives_present or pending:
+            marker = _marker_path(drive, pending)
+            other = _marker_path(drive, not pending)
+            marker.write_text(timestamp)
+            if other.exists():
+                other.unlink()

--- a/features/F3/test/acceptance.py
+++ b/features/F3/test/acceptance.py
@@ -4,12 +4,11 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
+import pytest
 
 from features.F2 import duplicate_finder
-from shared import compose, dump_logs, search_meili, wait_for
-
-import pytest
+from shared import compose, search_meili, wait_for
 
 
 def _run_once(
@@ -18,6 +17,10 @@ def _run_once(
     output_dir: Path,
     doc_relpaths: list[str],
     setup_input: Callable[[Path], None] | None = None,
+    *,
+    override_ids: dict[str, str] | None = None,
+    next_map: dict[str, str] | None = None,
+    env_file: Path | None = None,
 ) -> list[str]:
     if output_dir.exists():
         shutil.rmtree(output_dir)
@@ -38,33 +41,49 @@ def _run_once(
     by_path.mkdir(parents=True)
 
     doc_ids: list[str] = []
+    docs_by_id: dict[str, dict[str, Any]] = {}
     for i, doc_relpath in enumerate(doc_relpaths, start=1):
         doc_path = input_dir / doc_relpath
-        if doc_path.exists():
+        if override_ids and doc_relpath in override_ids:
+            doc_id = override_ids[doc_relpath]
+        elif doc_path.exists():
             doc_id = duplicate_finder.compute_hash(doc_path)
         else:
             doc_id = f"hash{i}"
         doc_ids.append(doc_id)
-        doc = {
-            "id": doc_id,
-            "paths": {doc_relpath: 1.0},
-            "paths_list": [doc_relpath],
-            "mtime": 1.0,
-            "size": 1,
-            "type": "text/plain",
-            "copies": 1,
-            "version": 1,
-            "next": "",
-        }
-        doc_dir = by_id / str(doc["id"])
-        doc_dir.mkdir()
-        (doc_dir / "document.json").write_text(json.dumps(doc))
-        link = by_path / Path(doc_relpath)
-        link.parent.mkdir(parents=True, exist_ok=True)
-        relative_target = os.path.relpath(by_id / str(doc["id"]), link.parent)
-        link.symlink_to(relative_target, target_is_directory=True)
+        doc = docs_by_id.get(doc_id)
+        if not doc:
+            doc = {
+                "id": doc_id,
+                "paths": {},
+                "paths_list": [],
+                "mtime": 1.0,
+                "size": 1,
+                "type": "text/plain",
+                "copies": 0,
+                "version": 1,
+                "next": "",
+            }
+            docs_by_id[doc_id] = doc
+        doc["paths"][doc_relpath] = 1.0
+        doc["paths_list"].append(doc_relpath)
+        doc["copies"] = len(doc["paths"])
+        if next_map and doc_relpath in next_map:
+            doc["next"] = next_map[doc_relpath]
 
-    compose(compose_file, workdir, "up", "-d")
+    for doc_id, doc in docs_by_id.items():
+        doc_dir = by_id / str(doc_id)
+        doc_dir.mkdir(exist_ok=True)
+        (doc_dir / "document.json").write_text(json.dumps(doc))
+        for relpath in doc["paths_list"]:
+            link = by_path / Path(relpath)
+            link.parent.mkdir(parents=True, exist_ok=True)
+            relative_target = os.path.relpath(by_id / str(doc_id), link.parent)
+            if link.is_symlink():
+                link.unlink()
+            link.symlink_to(relative_target, target_is_directory=True)
+
+    compose(compose_file, workdir, "up", "-d", env_file=env_file)
     by_id_dir = output_dir / "metadata" / "by-id"
     wait_for(
         lambda: by_id_dir.exists() and any(by_id_dir.iterdir()),
@@ -77,78 +96,357 @@ def _run_once(
     return doc_ids
 
 
-def test_offline_archive_workflow(tmp_path: Path) -> None:
+def _compose_paths() -> tuple[Path, Path, Path]:
     compose_file = Path(__file__).with_name("docker-compose.yml")
     workdir = compose_file.parent
     output_dir = workdir / "output"
+    return compose_file, workdir, output_dir
 
-    def offline_setup(input_dir: Path) -> None:
-        (input_dir / "archive").mkdir()
 
-    def removed_setup(input_dir: Path) -> None:
+def _run_sync(
+    compose_file: Path,
+    workdir: Path,
+    output_dir: Path,
+    doc_ids: list[str],
+    *,
+    env_file: Path | None = None,
+) -> None:
+    compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    by_id_dir = output_dir / "metadata" / "by-id"
+    wait_for(
+        lambda: all((by_id_dir / did).exists() for did in doc_ids),
+        message="metadata",
+    )
+    for doc_id in doc_ids:
+        search_meili(compose_file, workdir, f'id = "{doc_id}"')
+    compose(
+        compose_file,
+        workdir,
+        "down",
+        "--volumes",
+        "--rmi",
+        "local",
+        env_file=env_file,
+        check=False,
+    )
+
+
+def test_s1_drive_online(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+
+    def setup(input_dir: Path) -> None:
+        drive = input_dir / "archive" / "drive1"
+        drive.mkdir(parents=True)
+        (drive / "foo.txt").write_text("hi")
+
+    ids = _run_once(
+        compose_file, workdir, output_dir, ["archive/drive1/foo.txt"], setup
+    )
+    file_id = ids[0]
+    marker = workdir / "input" / "archive" / "drive1-status-ready"
+    assert marker.exists()
+    docs = search_meili(compose_file, workdir, f'id = "{file_id}"')
+    assert all(not doc["offline"] for doc in docs)
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s2_drive_unplugged(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+    ts = "2025-01-01T00:00:00Z"
+
+    def setup(input_dir: Path) -> None:
+        archive = input_dir / "archive"
+        archive.mkdir()
+        (archive / "drive1-status-ready").write_text(ts)
+
+    file_id = "hash1"
+    _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        ["archive/drive1/foo.txt"],
+        setup,
+        override_ids={"archive/drive1/foo.txt": file_id},
+    )
+    marker = workdir / "input" / "archive" / "drive1-status-ready"
+    assert marker.read_text() == ts
+    docs = search_meili(compose_file, workdir, f'id = "{file_id}"')
+    assert all(doc["offline"] for doc in docs)
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s3_drive_reattach_with_file(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+    ts = "2025-01-01T00:00:00Z"
+
+    def setup(input_dir: Path) -> None:
+        drive = input_dir / "archive" / "drive1"
+        drive.mkdir(parents=True)
+        (drive / "foo.txt").write_text("hi")
+        (input_dir / "archive" / "drive1-status-ready").write_text(ts)
+
+    file_id = "hash1"
+    _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        ["archive/drive1/foo.txt"],
+        setup,
+        override_ids={"archive/drive1/foo.txt": file_id},
+    )
+    marker = workdir / "input" / "archive" / "drive1-status-ready"
+    ts_new = marker.read_text()
+    assert ts_new != ts
+    docs = search_meili(compose_file, workdir, f'id = "{file_id}"')
+    assert all(not doc["offline"] for doc in docs)
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s4_drive_reattach_without_file(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+    ts = "2025-01-01T00:00:00Z"
+
+    def setup(input_dir: Path) -> None:
+        drive = input_dir / "archive" / "drive1"
+        drive.mkdir(parents=True)
+        (input_dir / "archive" / "drive1-status-ready").write_text(ts)
+
+    file_id = "hash1"
+    _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        [],
+        setup,
+    )
+    marker = workdir / "input" / "archive" / "drive1-status-ready"
+    ts_new = marker.read_text()
+    assert ts_new != ts
+    with pytest.raises(AssertionError):
+        search_meili(compose_file, workdir, f'id = "{file_id}"', timeout=5)
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s5_file_copied_online(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+
+    def setup(input_dir: Path) -> None:
+        drive = input_dir / "archive" / "drive1"
+        drive.mkdir(parents=True)
+        (drive / "bar.txt").write_text("hi")
+
+    ids = _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        ["archive/drive1/bar.txt"],
+        setup,
+        next_map={"archive/drive1/bar.txt": "mod"},
+    )
+    file_id = ids[0]
+    ready = workdir / "input" / "archive" / "drive1-status-ready"
+    pending = workdir / "input" / "archive" / "drive1-status-pending"
+    assert pending.exists()
+    assert not ready.exists()
+    docs = search_meili(compose_file, workdir, f'id = "{file_id}"')
+    assert all(not doc["offline"] for doc in docs)
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s6_file_exists_on_both_paths(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+
+    def setup(input_dir: Path) -> None:
+        drive = input_dir / "archive" / "drive1"
+        drive.mkdir(parents=True)
+        (drive / "baz.txt").write_text("hi")
+        (input_dir / "baz.txt").write_text("hi")
+
+    _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        ["archive/drive1/baz.txt", "baz.txt"],
+        setup,
+    )
+    doc_id = duplicate_finder.compute_hash(workdir / "input" / "baz.txt")
+    by_id = output_dir / "metadata" / "by-id" / doc_id
+    assert by_id.exists()
+    docs = search_meili(compose_file, workdir, f'id = "{doc_id}"')
+    assert all(not doc["offline"] for doc in docs)
+    ready = workdir / "input" / "archive" / "drive1-status-ready"
+    assert ready.exists()
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s7_online_copy_deleted_archive_offline(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+    ts = "2025-01-01T00:00:00Z"
+
+    def setup(input_dir: Path) -> None:
+        archive_dir = input_dir / "archive"
+        archive_dir.mkdir()
+        (archive_dir / "drive1-status-ready").write_text(ts)
+        doc_dir = output_dir / "metadata" / "by-id" / "hash1"
+        doc_dir.mkdir(parents=True)
+        doc = {
+            "id": "hash1",
+            "paths": {"archive/drive1/baz.txt": 1.0, "baz.txt": 1.0},
+            "paths_list": ["archive/drive1/baz.txt", "baz.txt"],
+            "mtime": 1.0,
+            "size": 1,
+            "type": "text/plain",
+            "copies": 2,
+            "version": 1,
+            "next": "",
+        }
+        (doc_dir / "document.json").write_text(json.dumps(doc))
+        link = output_dir / "metadata" / "by-path" / "archive" / "drive1" / "baz.txt"
+        link.parent.mkdir(parents=True, exist_ok=True)
+        relative_target = os.path.relpath(doc_dir, link.parent)
+        link.symlink_to(relative_target, target_is_directory=True)
+        link2 = output_dir / "metadata" / "by-path" / "baz.txt"
+        link2.parent.mkdir(parents=True, exist_ok=True)
+        relative_target2 = os.path.relpath(doc_dir, link2.parent)
+        link2.symlink_to(relative_target2, target_is_directory=True)
+
+    _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        [],
+        setup,
+        override_ids={},
+    )
+    marker = workdir / "input" / "archive" / "drive1-status-ready"
+    assert marker.read_text() == ts
+    docs = search_meili(compose_file, workdir, 'id = "hash1"')
+    assert all(doc["offline"] for doc in docs)
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s8_archive_drive_renamed(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+
+    def setup(input_dir: Path) -> None:
+        archive = input_dir / "archive"
+        archive.mkdir()
+        (archive / "drive1-status-ready").write_text("old")
         drive = input_dir / "archive" / "drive2"
         drive.mkdir(parents=True)
-        (drive / "bar.txt").write_text("persist")
+        (drive / "foo.txt").write_text("hi")
 
-    try:
-        ids = _run_once(
-            compose_file,
-            workdir,
-            output_dir,
-            ["archive/drive1/foo.txt"],
-            offline_setup,
+    _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        ["archive/drive2/foo.txt"],
+        setup,
+        override_ids={"archive/drive2/foo.txt": "hash1"},
+    )
+    old_marker = workdir / "input" / "archive" / "drive1-status-ready"
+    new_marker = workdir / "input" / "archive" / "drive2-status-ready"
+    assert not old_marker.exists()
+    assert new_marker.exists()
+    link = output_dir / "metadata" / "by-path" / "archive" / "drive2" / "foo.txt"
+    assert link.is_symlink()
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s9_multiple_drives_independent(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+
+    def setup(input_dir: Path) -> None:
+        drive1 = input_dir / "archive" / "drive1"
+        drive1.mkdir(parents=True)
+        (drive1 / "a.txt").write_text("a")
+        archive = input_dir / "archive"
+        (archive / "drive2-status-ready").write_text("old")
+
+    ids = _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        ["archive/drive1/a.txt", "archive/drive2/b.txt"],
+        setup,
+        override_ids={"archive/drive2/b.txt": "hash2"},
+    )
+    id1 = ids[0]
+    id2 = "hash2"
+    ready1 = workdir / "input" / "archive" / "drive1-status-ready"
+    ready2 = workdir / "input" / "archive" / "drive2-status-ready"
+    assert ready1.exists()
+    assert ready2.read_text() == "old"
+    docs1 = search_meili(compose_file, workdir, f'id = "{id1}"')
+    docs2 = search_meili(compose_file, workdir, f'id = "{id2}"')
+    assert all(not doc["offline"] for doc in docs1)
+    assert all(doc["offline"] for doc in docs2)
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+
+def test_s10_archive_directory_changed(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+
+    def setup(input_dir: Path) -> None:
+        drive = input_dir / "archive" / "drive1"
+        drive.mkdir(parents=True)
+        (drive / "foo.txt").write_text("hi")
+
+    ids = _run_once(
+        compose_file,
+        workdir,
+        output_dir,
+        ["archive/drive1/foo.txt"],
+        setup,
+    )
+    file_id = ids[0]
+
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)
+
+    input_dir = workdir / "input"
+    (input_dir / "archive").rename(input_dir / "archive2")
+    env_file = tmp_path / ".env"
+    env_file.write_text("ARCHIVE_DIRECTORY=/files/archive2\n")
+
+    _run_sync(
+        compose_file,
+        workdir,
+        output_dir,
+        [file_id],
+        env_file=env_file,
+    )
+
+    new_link = output_dir / "metadata" / "by-path" / "archive2" / "drive1" / "foo.txt"
+    old_link = output_dir / "metadata" / "by-path" / "archive" / "drive1" / "foo.txt"
+    assert new_link.is_symlink()
+    assert not old_link.exists()
+    marker = workdir / "input" / "archive2" / "drive1-status-ready"
+    assert marker.exists()
+    docs = search_meili(compose_file, workdir, f'id = "{file_id}"')
+    assert all(not doc["offline"] for doc in docs)
+
+
+def test_s11_status_files_ignored(tmp_path: Path) -> None:
+    compose_file, workdir, output_dir = _compose_paths()
+
+    def setup(input_dir: Path) -> None:
+        archive = input_dir / "archive"
+        archive.mkdir()
+        (archive / "Foo-status-ready").write_text("x")
+
+    _run_once(compose_file, workdir, output_dir, [], setup)
+    with pytest.raises(AssertionError):
+        search_meili(
+            compose_file, workdir, 'paths_list = "archive/Foo-status-ready"', timeout=5
         )
-        offline_id = ids[0]
-        doc_dir = output_dir / "metadata" / "by-id" / offline_id
-        assert (doc_dir / "document.json").exists()
-        assert (
-            output_dir / "metadata" / "by-path" / "archive" / "drive1" / "foo.txt"
-        ).is_symlink()
-        docs = search_meili(compose_file, workdir, f'id = "{offline_id}"')
-        assert any(doc["id"] == offline_id for doc in docs)
-        assert all(doc["offline"] for doc in docs)
-        assert all(doc["has_archive_paths"] for doc in docs)
 
-        compose(compose_file, workdir, "stop")
-        compose(compose_file, workdir, "rm", "-fsv")
-
-        ids = _run_once(
-            compose_file,
-            workdir,
-            output_dir,
-            ["archive/drive2/bar.txt"],
-            removed_setup,
-        )
-        online_id = ids[0]
-
-        docs = search_meili(compose_file, workdir, f'id = "{online_id}"')
-        assert any(doc["id"] == online_id for doc in docs)
-        assert all(not doc["offline"] for doc in docs)
-        assert all(doc["has_archive_paths"] for doc in docs)
-
-        doc_dir = output_dir / "metadata" / "by-id" / offline_id
-        assert not doc_dir.exists()
-        assert not (
-            output_dir / "metadata" / "by-path" / "archive" / "drive2" / "foo.txt"
-        ).exists()
-        assert (
-            output_dir / "metadata" / "by-id" / online_id / "document.json"
-        ).exists()
-        assert (
-            output_dir / "metadata" / "by-path" / "archive" / "drive2" / "bar.txt"
-        ).is_symlink()
-        with pytest.raises(AssertionError):
-            search_meili(compose_file, workdir, f'id = "{offline_id}"')
-    except Exception:
-        dump_logs(compose_file, workdir)
-        raise
-    finally:
-        compose(
-            compose_file,
-            workdir,
-            "down",
-            "--volumes",
-            "--rmi",
-            "local",
-            check=False,
-        )
+    compose(compose_file, workdir, "down", "--volumes", "--rmi", "local", check=False)

--- a/features/F3/test/docker-compose.yml
+++ b/features/F3/test/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - DEBUGPY_PORT=${DEBUGPY_PORT:-5678}
       - WAIT_FOR_DEBUGPY_CLIENT=${WAIT_FOR_DEBUGPY_CLIENT:-False}
     volumes:
-      - ./input:/files:ro
+      - ./input:/files
       - ./output:/home-index
     ports:
       - "5678:5678"

--- a/features/F4/modules.py
+++ b/features/F4/modules.py
@@ -204,11 +204,13 @@ async def update_doc_from_module(document: dict[str, Any]) -> dict[str, Any]:
     return document
 
 
-def set_next_modules(files_docs_by_hash: dict[str, dict[str, Any]]) -> None:
+def set_next_modules(
+    files_docs_by_hash: dict[str, dict[str, Any]], *, force_offline: bool = False
+) -> None:
     if not module_values:
         return
     for doc in files_docs_by_hash.values():
-        if doc_is_online(doc):
+        if force_offline or doc_is_online(doc):
             doc["next"] = module_values[0]["name"]
         else:
             doc["next"] = ""

--- a/features/F6/api.py
+++ b/features/F6/api.py
@@ -130,7 +130,9 @@ async def apply_ops(ops: FileOps) -> None:
             "next": "",
         }
         archive.update_archive_flags(doc)
-        modules_f4.set_next_modules({file_id: doc})
+        modules_f4.set_next_modules(
+            {file_id: doc}, force_offline=modules_f4.is_modules_changed
+        )
         metadata_store.write_doc_json(doc)
         path_links.link_path(item.path, file_id)
         docs_to_upsert[file_id] = doc
@@ -163,7 +165,9 @@ async def apply_ops(ops: FileOps) -> None:
         doc_data["type"] = hi.get_mime_type(dest)
         doc_data["version"] = hi.CURRENT_VERSION
         archive.update_archive_flags(doc_data)
-        modules_f4.set_next_modules({doc_id: doc_data})
+        modules_f4.set_next_modules(
+            {doc_id: doc_data}, force_offline=modules_f4.is_modules_changed
+        )
         metadata_store.write_doc_json(doc_data)
         docs_to_upsert[doc_id] = doc_data
 
@@ -194,7 +198,9 @@ async def apply_ops(ops: FileOps) -> None:
             doc_data_del["mtime"] = max(doc_data_del["paths"].values())
             doc_data_del["copies"] = len(doc_data_del["paths"])
             archive.update_archive_flags(doc_data_del)
-            modules_f4.set_next_modules({doc_id: doc_data_del})
+            modules_f4.set_next_modules(
+                {doc_id: doc_data_del}, force_offline=modules_f4.is_modules_changed
+            )
             metadata_store.write_doc_json(doc_data_del)
             docs_to_upsert[doc_id] = doc_data_del
 

--- a/tests/test_drive_markers.py
+++ b/tests/test_drive_markers.py
@@ -1,0 +1,190 @@
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _reload_hi(
+    monkeypatch: "pytest.MonkeyPatch", index_dir: Path, meta_dir: Path
+) -> ModuleType:
+    monkeypatch.setenv("INDEX_DIRECTORY", str(index_dir))
+    monkeypatch.setenv("ARCHIVE_DIRECTORY", str(index_dir / "archive"))
+    monkeypatch.setenv("METADATA_DIRECTORY", str(meta_dir))
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(meta_dir / "by-id"))
+    monkeypatch.setenv("BY_PATH_DIRECTORY", str(meta_dir / "by-path"))
+    return importlib.reload(__import__("main"))
+
+
+def test_update_drive_markers_creates_ready(tmp_path, monkeypatch):
+    index_dir = tmp_path / "index"
+    drive = index_dir / "archive" / "drive1"
+    drive.mkdir(parents=True)
+    meta_dir = tmp_path / "meta"
+    (meta_dir / "by-id").mkdir(parents=True)
+    (meta_dir / "by-path").mkdir()
+    hi = _reload_hi(monkeypatch, index_dir, meta_dir)
+
+    doc = {
+        "id": "1",
+        "paths": {"archive/drive1/foo.txt": 1.0},
+        "mtime": 1.0,
+        "size": 1,
+        "type": "text/plain",
+        "next": "",
+    }
+    hi.archive.update_drive_markers({"1": doc})
+    ready = index_dir / "archive" / "drive1-status-ready"
+    pending = index_dir / "archive" / "drive1-status-pending"
+    assert ready.exists()
+    assert not pending.exists()
+
+
+def test_update_drive_markers_pending(tmp_path, monkeypatch):
+    index_dir = tmp_path / "index"
+    drive = index_dir / "archive" / "drive1"
+    drive.mkdir(parents=True)
+    meta_dir = tmp_path / "meta"
+    (meta_dir / "by-id").mkdir(parents=True)
+    (meta_dir / "by-path").mkdir()
+    hi = _reload_hi(monkeypatch, index_dir, meta_dir)
+
+    doc = {
+        "id": "1",
+        "paths": {"archive/drive1/foo.txt": 1.0},
+        "mtime": 1.0,
+        "size": 1,
+        "type": "text/plain",
+        "next": "mod",
+    }
+    hi.archive.update_drive_markers({"1": doc})
+    ready = index_dir / "archive" / "drive1-status-ready"
+    pending = index_dir / "archive" / "drive1-status-pending"
+    assert pending.exists()
+    assert not ready.exists()
+
+
+def test_update_drive_markers_no_drive(tmp_path, monkeypatch):
+    index_dir = tmp_path / "index"
+    (index_dir / "archive").mkdir(parents=True)
+    meta_dir = tmp_path / "meta"
+    (meta_dir / "by-id").mkdir(parents=True)
+    (meta_dir / "by-path").mkdir()
+    hi = _reload_hi(monkeypatch, index_dir, meta_dir)
+
+    doc = {
+        "id": "1",
+        "paths": {"archive/drive1/foo.txt": 1.0},
+        "mtime": 1.0,
+        "size": 1,
+        "type": "text/plain",
+        "next": "",
+    }
+    hi.archive.update_drive_markers({"1": doc})
+    ready = index_dir / "archive" / "drive1-status-ready"
+    pending = index_dir / "archive" / "drive1-status-pending"
+    assert not ready.exists()
+    assert not pending.exists()
+
+
+def test_index_files_skips_status_files(tmp_path, monkeypatch):
+    index_dir = tmp_path / "index"
+    archive_dir = index_dir / "archive"
+    drive = archive_dir / "drive1"
+    drive.mkdir(parents=True)
+    (archive_dir / "drive1-status-ready").write_text("t")
+    file_path = drive / "foo.txt"
+    file_path.write_text("hi")
+
+    meta_dir = tmp_path / "meta"
+    by_id = meta_dir / "by-id"
+    by_path = meta_dir / "by-path"
+    by_id.mkdir(parents=True)
+    by_path.mkdir()
+
+    hi = _reload_hi(monkeypatch, index_dir, meta_dir)
+
+    md, mhr, ua_docs, ua_hashes, _ = hi.index_metadata()
+    files_docs, hashes = hi.index_files(md, mhr, ua_docs, ua_hashes)
+    assert len(files_docs) == 1
+    assert next(iter(files_docs.values()))["id"] == hi.duplicate_finder.compute_hash(
+        file_path
+    )
+    assert all(
+        "status-ready" not in p for p in next(iter(files_docs.values()))["paths"]
+    )
+
+
+def test_update_drive_markers_preserves_offline_marker(tmp_path, monkeypatch):
+    index_dir = tmp_path / "index"
+    archive_dir = index_dir / "archive"
+    archive_dir.mkdir(parents=True)
+    marker = archive_dir / "drive1-status-ready"
+    marker.write_text("ts")
+
+    meta_dir = tmp_path / "meta"
+    (meta_dir / "by-id").mkdir(parents=True)
+    (meta_dir / "by-path").mkdir()
+
+    hi = _reload_hi(monkeypatch, index_dir, meta_dir)
+
+    doc = {
+        "id": "1",
+        "paths": {"archive/drive1/foo.txt": 1.0},
+        "mtime": 1.0,
+        "size": 1,
+        "type": "text/plain",
+        "next": "",
+    }
+    hi.archive.update_drive_markers({"1": doc})
+
+    assert marker.exists()
+
+
+def test_update_drive_markers_offline_pending_on_modules_change(
+    tmp_path, monkeypatch
+) -> None:
+    index_dir = tmp_path / "index"
+    archive_dir = index_dir / "archive"
+    archive_dir.mkdir(parents=True)
+    ready = archive_dir / "drive1-status-ready"
+    ready.write_text("ts")
+
+    meta_dir = tmp_path / "meta"
+    (meta_dir / "by-id").mkdir(parents=True)
+    (meta_dir / "by-path").mkdir()
+
+    hi = _reload_hi(monkeypatch, index_dir, meta_dir)
+    monkeypatch.setattr(hi.modules_f4, "is_modules_changed", True)
+
+    doc = {
+        "id": "1",
+        "paths": {"archive/drive1/foo.txt": 1.0},
+        "mtime": 1.0,
+        "size": 1,
+        "type": "text/plain",
+        "next": "mod",
+    }
+    hi.archive.update_drive_markers({"1": doc})
+
+    pending = archive_dir / "drive1-status-pending"
+    assert pending.exists()
+    assert not ready.exists()
+
+
+def test_update_drive_markers_removes_orphan_marker(tmp_path, monkeypatch):
+    index_dir = tmp_path / "index"
+    archive_dir = index_dir / "archive"
+    archive_dir.mkdir(parents=True)
+    marker = archive_dir / "drive1-status-ready"
+    marker.write_text("ts")
+
+    meta_dir = tmp_path / "meta"
+    (meta_dir / "by-id").mkdir(parents=True)
+    (meta_dir / "by-path").mkdir()
+
+    hi = _reload_hi(monkeypatch, index_dir, meta_dir)
+
+    hi.archive.update_drive_markers({})
+
+    assert not marker.exists()

--- a/tests/test_f4_module_helpers.py
+++ b/tests/test_f4_module_helpers.py
@@ -56,6 +56,24 @@ def test_set_next_modules_assigns_module_names(
     assert docs["2"]["next"] == "m1"
 
 
+def test_set_next_modules_force_offline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    modules = _reload_modules(monkeypatch, tmp_path)
+
+    modules.module_values = [
+        {"name": "m1"},
+    ]
+    modules.modules = {"m1": modules.module_values[0]}
+
+    docs = {"1": {"id": "1", "next": ""}}
+
+    monkeypatch.setattr(modules, "doc_is_online", lambda doc: False)
+
+    modules.set_next_modules(docs, force_offline=True)
+    assert docs["1"]["next"] == "m1"
+
+
 def test_update_doc_from_module_updates_and_saves(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_f6_api.py
+++ b/tests/test_f6_api.py
@@ -139,7 +139,7 @@ def test_apply_ops_add_move_delete(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(path_links, "by_path_directory", lambda: links)
 
     monkeypatch.setattr(archive, "update_archive_flags", lambda d: None)
-    monkeypatch.setattr(modules_f4, "set_next_modules", lambda d: None)
+    monkeypatch.setattr(modules_f4, "set_next_modules", lambda d, **kw: None)
 
     added: dict[str, Any] = {}
     deleted: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- keep existing drive markers if a drive directory is missing
- verify offline marker persistence and skip marker files in unit tests
- split F3 acceptance tests by scenario and add coverage for scenarios 1-4 and 11
- add scenario 10 acceptance test for archive directory changes
- handle moved archive files so old drive paths disappear
- update drive marker logic for module changes

## Testing
- `./agents-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6879c1c0614c832bb7fad20c05d76b0b