### PR TITLE
Increase F2 unit test coverage

### DIFF
--- a/tests/test_f2_duplicate_finder.py
+++ b/tests/test_f2_duplicate_finder.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_truncate_mtime_rounds_down():
+    import features.F2.duplicate_finder as df
+
+    assert df.truncate_mtime(1.23456) == pytest.approx(1.2345)
+
+
+def test_compute_hash_returns_string(tmp_path: Path):
+    import features.F2.duplicate_finder as df
+
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("hi")
+    assert df.compute_hash(file_path) == "0"
+
+
+def test_determine_hash_uses_cached(monkeypatch, tmp_path: Path):
+    import features.F2.duplicate_finder as df
+
+    index_dir = tmp_path
+    file_path = index_dir / "a.txt"
+    file_path.write_text("data")
+
+    stat = file_path.stat()
+    prev_hash = "cached"
+    docs = {prev_hash: {"paths": {"a.txt": df.truncate_mtime(stat.st_mtime)}}}
+    hashes = {"a.txt": prev_hash}
+
+    def fake_compute(_):
+        raise AssertionError("compute_hash called")
+
+    monkeypatch.setattr(df, "compute_hash", fake_compute)
+    path, h, st = df.determine_hash(file_path, index_dir, docs, hashes)
+    assert path == file_path
+    assert h == prev_hash
+    assert st.st_size == stat.st_size
+
+
+def test_determine_hash_recomputes_when_mtime_changes(monkeypatch, tmp_path: Path):
+    import features.F2.duplicate_finder as df
+
+    index_dir = tmp_path
+    file_path = index_dir / "b.txt"
+    file_path.write_text("x")
+
+    prev_hash = "cached"
+    docs = {prev_hash: {"paths": {"b.txt": 0.0}}}
+    hashes = {"b.txt": prev_hash}
+    called = {}
+
+    def fake_compute(_):
+        called["yes"] = True
+        return "new"
+
+    monkeypatch.setattr(df, "compute_hash", fake_compute)
+    path, h, st = df.determine_hash(file_path, index_dir, docs, hashes)
+    assert path == file_path
+    assert h == "new"
+    assert called.get("yes")

--- a/tests/test_f2_metadata_store.py
+++ b/tests/test_f2_metadata_store.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+
+def test_add_paths_list_populates_and_sorts():
+    import features.F2.metadata_store as ms
+
+    doc = {"paths": {"b": 1.0, "a": 2.0}}
+    ms._add_paths_list(doc)
+    assert doc["paths_list"] == ["a", "b"]
+    assert doc["version"] == 1
+
+
+def test_write_doc_json_creates_directories(monkeypatch, tmp_path: Path):
+    import features.F2.metadata_store as ms
+
+    monkeypatch.setenv("METADATA_DIRECTORY", str(tmp_path / "meta"))
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(tmp_path / "meta" / "by-id"))
+    doc = {"id": "x", "paths": {}}
+    ms.write_doc_json(doc)
+    target = tmp_path / "meta" / "by-id" / "x" / "document.json"
+    assert target.exists()
+    assert json.loads(target.read_text())["id"] == "x"

--- a/tests/test_f2_path_links.py
+++ b/tests/test_f2_path_links.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+
+
+def test_link_and_unlink(monkeypatch, tmp_path: Path):
+    import features.F2.path_links as pl
+    import features.F2.metadata_store as ms
+
+    by_id = tmp_path / "by-id"
+    by_path = tmp_path / "by-path"
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(by_id))
+    monkeypatch.setenv("BY_PATH_DIRECTORY", str(by_path))
+    ms.ensure_directories()
+    target = by_id / "123"
+    target.mkdir(parents=True)
+
+    pl.link_path("sub/file.txt", "123")
+    link = by_path / "sub" / "file.txt"
+    assert link.is_symlink()
+    assert os.readlink(link) == os.path.relpath(target, link.parent)
+
+    pl.unlink_path("sub/file.txt")
+    assert not link.exists()
+    assert not (by_path / "sub").exists()

--- a/tests/test_f2_search_index.py
+++ b/tests/test_f2_search_index.py
@@ -1,0 +1,130 @@
+import asyncio
+import pytest
+
+
+class DummyIndex:
+    def __init__(self):
+        self.updated = []
+        self.deleted = []
+        self.documents: list[dict] = []
+        self.stats = type("Stats", (), {"number_of_documents": 3})()
+
+    async def update_documents(self, docs):
+        self.updated.append(list(docs))
+
+    async def delete_documents(self, ids=None):
+        self.deleted.append(list(ids))
+
+    async def get_stats(self):
+        return self.stats
+
+    async def get_document(self, doc_id):
+        return {"id": doc_id}
+
+    async def get_documents(self, offset=0, limit=10, filter=None):
+        docs = self.documents
+        if filter:
+            key, value = filter.split(" = ")
+            docs = [d for d in docs if str(d.get(key)) == value]
+        return type("Resp", (), {"results": docs[offset : offset + limit]})()
+
+
+class DummyChunkIndex(DummyIndex):
+    pass
+
+
+class DummyClient:
+    def __init__(self):
+        self.calls = 0
+
+    async def get_tasks(self):
+        if self.calls == 0:
+            self.calls += 1
+            task = type("Task", (), {"status": "processing"})()
+            return type("Resp", (), {"results": [task]})()
+        return type("Resp", (), {"results": []})()
+
+
+def setup(monkeypatch):
+    import features.F2.search_index as si
+
+    idx = DummyIndex()
+    cidx = DummyChunkIndex()
+    cli = DummyClient()
+    monkeypatch.setattr(si, "index", idx)
+    monkeypatch.setattr(si, "chunk_index", cidx)
+    monkeypatch.setattr(si, "client", cli)
+    monkeypatch.setattr(si, "MEILISEARCH_BATCH_SIZE", 2)
+    return si, idx, cidx, cli
+
+
+def test_add_and_delete_documents(monkeypatch):
+    si, idx, _, _ = setup(monkeypatch)
+    asyncio.run(si.add_or_update_documents([{"id": 1}, {"id": 2}, {"id": 3}]))
+    assert idx.updated == [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+    asyncio.run(si.delete_docs_by_id(["a", "b", "c"]))
+    assert idx.deleted == [["a", "b"], ["c"]]
+
+
+def test_chunk_document_operations(monkeypatch):
+    si, _, cidx, _ = setup(monkeypatch)
+    asyncio.run(si.add_or_update_chunk_documents([{"id": 1}, {"id": 2}, {"id": 3}]))
+    assert cidx.updated == [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+    asyncio.run(si.delete_chunk_docs_by_id(["x", "y", "z"]))
+    assert cidx.deleted == [["x", "y"], ["z"]]
+
+
+def test_delete_chunk_docs_by_file_id(monkeypatch):
+    si, _, cidx, _ = setup(monkeypatch)
+    cidx.documents = [
+        {"id": "1", "file_id": "f1"},
+        {"id": "2", "file_id": "f2"},
+        {"id": "3", "file_id": "f1"},
+    ]
+    asyncio.run(si.delete_chunk_docs_by_file_ids(["f1"]))
+    assert cidx.deleted == [["1", "3"]]
+
+
+def test_delete_chunk_docs_by_file_id_and_module(monkeypatch):
+    si, _, cidx, _ = setup(monkeypatch)
+    cidx.documents = [
+        {"id": "1", "file_id": "f1", "module": "m1"},
+        {"id": "2", "file_id": "f1", "module": "m2"},
+    ]
+    asyncio.run(si.delete_chunk_docs_by_file_id_and_module("f1", "m1"))
+    assert cidx.deleted == [["1"]]
+
+
+def test_getters(monkeypatch):
+    si, idx, _, _ = setup(monkeypatch)
+    idx.documents = [{"id": "1", "next": "run"}, {"id": "2", "next": "check"}]
+    assert asyncio.run(si.get_document_count()) == 3
+    assert asyncio.run(si.get_document("1")) == {"id": "1"}
+    assert asyncio.run(si.get_all_documents()) == idx.documents
+    assert asyncio.run(si.get_all_pending_jobs("run")) == [{"id": "1", "next": "run"}]
+
+
+def test_wait_for_meili_idle(monkeypatch):
+    si, _, _, cli = setup(monkeypatch)
+    sleep_calls = []
+
+    async def fake_sleep(_):
+        sleep_calls.append(1)
+
+    monkeypatch.setattr(si.asyncio, "sleep", fake_sleep)
+    asyncio.run(si.wait_for_meili_idle())
+    assert sleep_calls
+
+
+def test_errors_when_not_initialised(monkeypatch):
+    import features.F2.search_index as si
+
+    monkeypatch.setattr(si, "index", None)
+    with pytest.raises(RuntimeError):
+        asyncio.run(si.add_or_update_documents([]))
+    monkeypatch.setattr(si, "chunk_index", None)
+    with pytest.raises(RuntimeError):
+        asyncio.run(si.add_or_update_chunk_documents([]))
+    monkeypatch.setattr(si, "client", None)
+    with pytest.raises(RuntimeError):
+        asyncio.run(si.wait_for_meili_idle())


### PR DESCRIPTION
## Summary
- add dedicated unit tests covering F2 components
- ensure search index helper functions exercised

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687bfbd133f4832bb2b765a38a313170