### PR TITLE
Add F5 chunking unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ your files using a locally run language model backed by Meilisearch.
 Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Planned Maintenance
-None
+- Expand unit test coverage for F6 API server

--- a/tests/test_f5_chunk_module.py
+++ b/tests/test_f5_chunk_module.py
@@ -1,0 +1,33 @@
+import json
+
+
+def test_check_returns_true_when_no_content(tmp_path):
+    from features.F5.chunk_module import main as chunk_module
+
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("hello")
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    assert chunk_module.check(file_path, {}, meta_dir)
+
+
+def test_check_detects_identical_content(tmp_path):
+    from features.F5.chunk_module import main as chunk_module
+
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("hello")
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    (meta_dir / "content.json").write_text(json.dumps("hello"))
+    assert not chunk_module.check(file_path, {}, meta_dir)
+
+
+def test_run_reads_file_and_returns_document(tmp_path):
+    from features.F5.chunk_module import main as chunk_module
+
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("hello")
+    doc = {"id": "1"}
+    result = chunk_module.run(file_path, doc, tmp_path)
+    assert result["document"] == doc
+    assert result["content"] == "hello"

--- a/tests/test_f5_chunking.py
+++ b/tests/test_f5_chunking.py
@@ -1,0 +1,105 @@
+import asyncio
+
+
+def _setup(monkeypatch, tmp_path):
+    monkeypatch.setenv("BY_ID_DIRECTORY", str(tmp_path))
+    import features.F5.chunking as chunking
+    import features.F2.search_index as search_index
+    import importlib
+
+    importlib.reload(chunking)
+    importlib.reload(search_index)
+    return chunking, search_index
+
+
+def test_add_content_chunks_writes_and_indexes(monkeypatch, tmp_path):
+    chunking, search_index = _setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(chunking.metadata_store, "by_id_directory", lambda: tmp_path)
+
+    recorded = {}
+
+    async def fake_delete(file_id, module):
+        recorded["delete"] = (file_id, module)
+
+    async def fake_add(docs):
+        recorded["add"] = docs
+
+    monkeypatch.setattr(
+        search_index, "delete_chunk_docs_by_file_id_and_module", fake_delete
+    )
+    monkeypatch.setattr(search_index, "add_or_update_chunk_documents", fake_add)
+    monkeypatch.setattr(
+        chunking, "build_chunk_docs_from_content", lambda *a, **k: [{"id": "x"}]
+    )
+    monkeypatch.setattr(
+        chunking.chunk_utils,
+        "write_chunk_docs",
+        lambda p, d: recorded.setdefault("write", p),
+    )
+
+    asyncio.run(
+        chunking.add_content_chunks({"id": "f", "mtime": 1.0}, "mod", content="hi")
+    )
+
+    assert recorded["delete"] == ("f", "mod")
+    assert recorded["add"] == [{"id": "x"}]
+    assert recorded["write"] == tmp_path / "f" / "mod"
+    assert (tmp_path / "f" / "mod" / "content.json").exists()
+
+
+def test_add_content_chunks_no_content_skips(monkeypatch, tmp_path):
+    chunking, search_index = _setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(chunking.metadata_store, "by_id_directory", lambda: tmp_path)
+
+    recorded = {}
+
+    async def fake_delete(*_args):
+        recorded["delete"] = True
+
+    async def fake_add(*_args):
+        recorded["add"] = True
+
+    monkeypatch.setattr(
+        search_index, "delete_chunk_docs_by_file_id_and_module", fake_delete
+    )
+    monkeypatch.setattr(search_index, "add_or_update_chunk_documents", fake_add)
+
+    asyncio.run(chunking.add_content_chunks({"id": "f"}, "mod"))
+
+    assert "delete" not in recorded
+    assert "add" not in recorded
+
+
+def test_add_content_chunks_reads_existing_content(monkeypatch, tmp_path):
+    chunking, search_index = _setup(monkeypatch, tmp_path)
+    monkeypatch.setattr(chunking.metadata_store, "by_id_directory", lambda: tmp_path)
+
+    (tmp_path / "f" / "mod").mkdir(parents=True)
+    (tmp_path / "f" / "mod" / "content.json").write_text('"hi"')
+
+    recorded = {}
+
+    async def fake_delete(file_id, module):
+        recorded["delete"] = (file_id, module)
+
+    async def fake_add(docs):
+        recorded["add"] = docs
+
+    monkeypatch.setattr(
+        search_index, "delete_chunk_docs_by_file_id_and_module", fake_delete
+    )
+    monkeypatch.setattr(search_index, "add_or_update_chunk_documents", fake_add)
+    monkeypatch.setattr(
+        chunking, "build_chunk_docs_from_content", lambda *a, **k: [{"id": "y"}]
+    )
+    monkeypatch.setattr(
+        chunking.chunk_utils,
+        "write_chunk_docs",
+        lambda p, d: recorded.setdefault("write", p),
+    )
+
+    asyncio.run(chunking.add_content_chunks({"id": "f"}, "mod"))
+
+    assert recorded["delete"] == ("f", "mod")
+    assert recorded["add"] == [{"id": "y"}]
+    assert recorded["write"] == tmp_path / "f" / "mod"


### PR DESCRIPTION
## Summary
- add tests for F5 chunk_module check/run helpers
- add tests for F5 chunking.add_content_chunks
- document planned maintenance item for F6 API tests

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c19a4f47c832bacd9a5ad3ea23f8e