### PR TITLE
Add F6 server unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ your files using a locally run language model backed by Meilisearch.
 Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Planned Maintenance
-- Expand unit test coverage for F6 API server
+- None

--- a/tests/test_f6_server.py
+++ b/tests/test_f6_server.py
@@ -1,0 +1,45 @@
+import asyncio
+from features.F6 import server
+
+
+def test_serve_api_runs_uvicorn(monkeypatch):
+    called = {}
+
+    class DummyConfig:
+        def __init__(self, app, host, port, loop):
+            called["app"] = app
+            called["host"] = host
+            called["port"] = port
+            called["loop"] = loop
+
+    class DummyServer:
+        def __init__(self, config):
+            called["config"] = config
+
+        async def serve(self):
+            called["served"] = True
+
+    monkeypatch.setattr(
+        server,
+        "uvicorn",
+        type(
+            "UV",
+            (),
+            {
+                "Config": DummyConfig,
+                "Server": DummyServer,
+            },
+        ),
+    )
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(server.serve_api())
+    loop.close()
+    asyncio.set_event_loop(None)
+
+    assert called["app"] is server.app
+    assert called["host"] == "0.0.0.0"
+    assert called["port"] == server.API_PORT
+    assert called["loop"] == "asyncio"
+    assert called["served"] is True


### PR DESCRIPTION
## Summary
- add test for F6 server's `serve_api`
- remove finished maintenance item

## Testing
- `bash agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c1de596e0832b934d315f69bc11bc