### PR TITLE
Ensure acceptance tests log failures

### DIFF
--- a/features/F4/test/acceptance.py
+++ b/features/F4/test/acceptance.py
@@ -94,18 +94,23 @@ def _run_again(
     """Run the stack again without wiping ``output_dir``."""
     env_file.write_text(f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\n")
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
-    _get_doc_id(workdir, output_dir)
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+    try:
+        _get_doc_id(workdir, output_dir)
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
 
 
 def _run_add_module(
@@ -120,22 +125,32 @@ def _run_add_module(
     )
     env_file.write_text(f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\n")
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
-    doc_id = _get_doc_id(workdir, output_dir)
-    version_file = (
-        output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "version.json"
-    )
-    wait_for(version_file.exists, timeout=300, message="module output")
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+    try:
+        doc_id = _get_doc_id(workdir, output_dir)
+        version_file = (
+            output_dir
+            / "metadata"
+            / "by-id"
+            / doc_id
+            / "timeout-module"
+            / "version.json"
+        )
+        wait_for(version_file.exists, timeout=300, message="module output")
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
 
 
 def _run_remove_drive_mid(
@@ -152,33 +167,39 @@ def _run_remove_drive_mid(
         f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nMODULE_SLEEP=2\nUID_RETRY_SECONDS=1\n"
     )
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
-    doc_a = _get_doc_id(workdir, output_dir, "archive/drive1/a.txt")
-    doc_b = _get_doc_id(workdir, output_dir, "archive/drive1/b.txt")
-    wait_for(
-        (
-            output_dir
-            / "metadata"
-            / "by-id"
-            / doc_a
-            / "example-module"
-            / "version.json"
-        ).exists,
-        timeout=300,
-        message="module a",
-    )
-    shutil.rmtree(workdir / "input" / "archive" / "drive1")
-    time.sleep(3)
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+    doc_a = doc_b = ""
+    try:
+        doc_a = _get_doc_id(workdir, output_dir, "archive/drive1/a.txt")
+        doc_b = _get_doc_id(workdir, output_dir, "archive/drive1/b.txt")
+        wait_for(
+            (
+                output_dir
+                / "metadata"
+                / "by-id"
+                / doc_a
+                / "example-module"
+                / "version.json"
+            ).exists,
+            timeout=300,
+            message="module a",
+        )
+        shutil.rmtree(workdir / "input" / "archive" / "drive1")
+        time.sleep(3)
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
     return doc_a, doc_b
 
 
@@ -196,40 +217,51 @@ def _run_uid_mismatch(
         f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nUID_RETRY_SECONDS=1\n"
     )
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
-    doc_id = duplicate_finder.compute_hash(workdir / "input" / "hello.txt")
-    bad = json.dumps({"id": doc_id, "paths": {"hello.txt": 1}, "uid": "bad"})
-    _redis_cmd(compose_file, workdir, "RPUSH", "example-module:run", bad)
-    wait_for(
-        lambda: "uid mismatch"
-        in _container_logs(compose_file, workdir, "example-module"),
-        timeout=60,
-        message="uid warning",
-    )
-    count = _redis_llen(compose_file, workdir, "example-module:run")
-    assert count == 1
-    good = json.dumps(
-        {
-            "id": doc_id,
-            "paths": {"hello.txt": 1},
-            "uid": "00000000-0000-0000-0000-000000000001",
-        }
-    )
-    _redis_cmd(compose_file, workdir, "RPUSH", "example-module:run", good)
-    version_file = (
-        output_dir / "metadata" / "by-id" / doc_id / "example-module" / "version.json"
-    )
-    wait_for(version_file.exists, timeout=300, message="module output")
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+    doc_id = ""
+    try:
+        doc_id = duplicate_finder.compute_hash(workdir / "input" / "hello.txt")
+        bad = json.dumps({"id": doc_id, "paths": {"hello.txt": 1}, "uid": "bad"})
+        _redis_cmd(compose_file, workdir, "RPUSH", "example-module:run", bad)
+        wait_for(
+            lambda: "uid mismatch"
+            in _container_logs(compose_file, workdir, "example-module"),
+            timeout=60,
+            message="uid warning",
+        )
+        count = _redis_llen(compose_file, workdir, "example-module:run")
+        assert count == 1
+        good = json.dumps(
+            {
+                "id": doc_id,
+                "paths": {"hello.txt": 1},
+                "uid": "00000000-0000-0000-0000-000000000001",
+            }
+        )
+        _redis_cmd(compose_file, workdir, "RPUSH", "example-module:run", good)
+        version_file = (
+            output_dir
+            / "metadata"
+            / "by-id"
+            / doc_id
+            / "example-module"
+            / "version.json"
+        )
+        wait_for(version_file.exists, timeout=300, message="module output")
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
     return doc_id
 
 
@@ -251,36 +283,49 @@ def _run_crash_isolation(
         "CRASH=1\nEXAMPLE_TIMEOUT=1\nCRASH_TIMEOUT=1\n"
     )
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
-    doc_id = duplicate_finder.compute_hash(workdir / "input" / "hello.txt")
-    job = json.dumps(
-        {
-            "id": doc_id,
-            "paths": {"hello.txt": 1},
-            "uid": "00000000-0000-0000-0000-000000000003",
-        }
-    )
-    _redis_cmd(compose_file, workdir, "RPUSH", "crash-module:run", job)
-    version_file = (
-        output_dir / "metadata" / "by-id" / doc_id / "example-module" / "version.json"
-    )
-    wait_for(version_file.exists, timeout=300, message="example output")
-    wait_for(
-        lambda: _container_status(compose_file, workdir, "crash-module") == "exited",
-        timeout=60,
-        message="crash exit",
-    )
-    logs = _container_logs(compose_file, workdir, "crash-module")
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+    doc_id = ""
+    logs = ""
+    try:
+        doc_id = duplicate_finder.compute_hash(workdir / "input" / "hello.txt")
+        job = json.dumps(
+            {
+                "id": doc_id,
+                "paths": {"hello.txt": 1},
+                "uid": "00000000-0000-0000-0000-000000000003",
+            }
+        )
+        _redis_cmd(compose_file, workdir, "RPUSH", "crash-module:run", job)
+        version_file = (
+            output_dir
+            / "metadata"
+            / "by-id"
+            / doc_id
+            / "example-module"
+            / "version.json"
+        )
+        wait_for(version_file.exists, timeout=300, message="example output")
+        wait_for(
+            lambda: _container_status(compose_file, workdir, "crash-module")
+            == "exited",
+            timeout=60,
+            message="crash exit",
+        )
+        logs = _container_logs(compose_file, workdir, "crash-module")
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
     return doc_id, logs
 
 
@@ -303,44 +348,61 @@ def _run_share_group_rotation(
         "EXAMPLE_TIMEOUT=1\nTIMEOUT_TIMEOUT=1\n"
     )
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
-    doc_id = duplicate_finder.compute_hash(workdir / "input" / "hello.txt")
-    job = json.dumps(
-        {
-            "id": doc_id,
-            "paths": {"hello.txt": 1},
-            "uid": "00000000-0000-0000-0000-000000000002",
-        }
-    )
-    _redis_cmd(compose_file, workdir, "RPUSH", "timeout-module:run", job)
-    job2 = json.dumps(
-        {
-            "id": doc_id,
-            "paths": {"hello.txt": 1},
-            "uid": "00000000-0000-0000-0000-000000000001",
-        }
-    )
-    _redis_cmd(compose_file, workdir, "RPUSH", "example-module:run", job2)
-    version_timeout = (
-        output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "version.json"
-    )
-    version_example = (
-        output_dir / "metadata" / "by-id" / doc_id / "example-module" / "version.json"
-    )
-    wait_for(version_example.exists, timeout=300, message="example output")
-    wait_for(version_timeout.exists, timeout=300, message="timeout output")
-    logs_example = _container_logs(compose_file, workdir, "example-module")
-    logs_timeout = _container_logs(compose_file, workdir, "timeout-module")
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+    logs_example = ""
+    logs_timeout = ""
+    try:
+        doc_id = duplicate_finder.compute_hash(workdir / "input" / "hello.txt")
+        job = json.dumps(
+            {
+                "id": doc_id,
+                "paths": {"hello.txt": 1},
+                "uid": "00000000-0000-0000-0000-000000000002",
+            }
+        )
+        _redis_cmd(compose_file, workdir, "RPUSH", "timeout-module:run", job)
+        job2 = json.dumps(
+            {
+                "id": doc_id,
+                "paths": {"hello.txt": 1},
+                "uid": "00000000-0000-0000-0000-000000000001",
+            }
+        )
+        _redis_cmd(compose_file, workdir, "RPUSH", "example-module:run", job2)
+        version_timeout = (
+            output_dir
+            / "metadata"
+            / "by-id"
+            / doc_id
+            / "timeout-module"
+            / "version.json"
+        )
+        version_example = (
+            output_dir
+            / "metadata"
+            / "by-id"
+            / doc_id
+            / "example-module"
+            / "version.json"
+        )
+        wait_for(version_example.exists, timeout=300, message="example output")
+        wait_for(version_timeout.exists, timeout=300, message="timeout output")
+        logs_example = _container_logs(compose_file, workdir, "example-module")
+        logs_timeout = _container_logs(compose_file, workdir, "timeout-module")
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
     return logs_example, logs_timeout
 
 
@@ -543,44 +605,54 @@ def _run_timeout(
     )
 
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    try:
+        doc_id = _get_doc_id(workdir, output_dir)
+        log_file = (
+            output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "log.txt"
+        )
+        wait_for(log_file.exists, timeout=120, message="timeout log")
+        # allow the job to time out
+        wait_for(
+            lambda: _redis_llen(compose_file, workdir, "modules:done") == 0,
+            timeout=60,
+            message="no done",
+        )
 
-    doc_id = _get_doc_id(workdir, output_dir)
-    log_file = output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "log.txt"
-    wait_for(log_file.exists, timeout=120, message="timeout log")
-    # allow the job to time out
-    wait_for(
-        lambda: _redis_llen(compose_file, workdir, "modules:done") == 0,
-        timeout=60,
-        message="no done",
-    )
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
 
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        env_file.write_text(
+            f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=0\n"
+        )
+        compose(compose_file, workdir, "up", "-d", env_file=env_file)
 
-    env_file.write_text(
-        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nMODULE_SLEEP=0\n"
-    )
-    compose(compose_file, workdir, "up", "-d", env_file=env_file)
-
-    version_file = (
-        output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "version.json"
-    )
-    wait_for(version_file.exists, timeout=300, message="module output")
-    logs = log_file.read_text().splitlines()
-    assert sum(1 for line in logs if "start" in line) >= 2
-    docs = search_meili(compose_file, workdir, f'id = "{doc_id}"', timeout=300)
-    assert any(doc["id"] == doc_id for doc in docs)
-
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+        version_file = (
+            output_dir
+            / "metadata"
+            / "by-id"
+            / doc_id
+            / "timeout-module"
+            / "version.json"
+        )
+        wait_for(version_file.exists, timeout=300, message="module output")
+        logs = log_file.read_text().splitlines()
+        assert sum(1 for line in logs if "start" in line) >= 2
+        docs = search_meili(compose_file, workdir, f'id = "{doc_id}"', timeout=300)
+        assert any(doc["id"] == doc_id for doc in docs)
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
 
 
 def _run_check_timeout(
@@ -598,44 +670,54 @@ def _run_check_timeout(
     )
 
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    try:
+        doc_id = _get_doc_id(workdir, output_dir)
 
-    doc_id = _get_doc_id(workdir, output_dir)
+        wait_for(
+            lambda: _redis_llen(
+                compose_file, workdir, "timeout-module:check:processing"
+            )
+            > 0,
+            timeout=60,
+            message="processing",
+        )
+        wait_for(
+            lambda: _redis_llen(compose_file, workdir, "timeout-module:check") == 1,
+            timeout=120,
+            message="requeued",
+        )
 
-    wait_for(
-        lambda: _redis_llen(compose_file, workdir, "timeout-module:check:processing")
-        > 0,
-        timeout=60,
-        message="processing",
-    )
-    wait_for(
-        lambda: _redis_llen(compose_file, workdir, "timeout-module:check") == 1,
-        timeout=120,
-        message="requeued",
-    )
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
 
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        env_file.write_text(
+            f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=0\nMODULE_SLEEP=0\n"
+        )
+        compose(compose_file, workdir, "up", "-d", env_file=env_file)
 
-    env_file.write_text(
-        f"COMMIT_SHA={os.environ.get('COMMIT_SHA', 'main')}\nTIMEOUT=1\nCHECK_SLEEP=0\nMODULE_SLEEP=0\n"
-    )
-    compose(compose_file, workdir, "up", "-d", env_file=env_file)
-
-    version_file = (
-        output_dir / "metadata" / "by-id" / doc_id / "timeout-module" / "version.json"
-    )
-    wait_for(version_file.exists, timeout=300, message="module output")
-
-    compose(compose_file, workdir, "stop", env_file=env_file, check=False)
-    compose(
-        compose_file,
-        workdir,
-        "down",
-        "--volumes",
-        "--rmi",
-        "local",
-        env_file=env_file,
-        check=False,
-    )
+        version_file = (
+            output_dir
+            / "metadata"
+            / "by-id"
+            / doc_id
+            / "timeout-module"
+            / "version.json"
+        )
+        wait_for(version_file.exists, timeout=300, message="module output")
+    except Exception:
+        dump_logs(compose_file, workdir)
+        raise
+    finally:
+        compose(compose_file, workdir, "stop", env_file=env_file, check=False)
+        compose(
+            compose_file,
+            workdir,
+            "down",
+            "--volumes",
+            "--rmi",
+            "local",
+            env_file=env_file,
+            check=False,
+        )
 
 
 def test_s8_run_timeout(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure container logs are dumped on failures in F4 acceptance helpers
- run formatting and tests

## Testing
- `./agents-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c2873a1fc832b9ec92fe98aa261b4