### PR TITLE
Enable persistent redis queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ A few maintained modules provide common functionality out of the box:
 [home-index-rag-query](https://github.com/nashspence/home-index-rag-query) – offers a Streamlit-driven RAG experience, letting you ask questions against
 your files using a locally run language model backed by Meilisearch.
 
+## Running locally
+
+The provided `docker-compose.yml` starts Home‑Index along with Meilisearch and
+Redis. Redis writes an append‑only log (`appendonly yes`) so module queues
+survive container restarts. The Redis documentation explains that enabling the
+Append Only File offers better durability than the default snapshot mode which
+uses `appendonly no`. Data persists on a local volume. Bring
+everything up with:
+
+```bash
+docker-compose up -d
+```
+
+Data persists under `./docker-data` with the following structure:
+
+ - `files/` – your project files mounted under `/files` and writable by default; mount read‑only only if you won't use the WebDAV API
+- `home-index/` – metadata, logs and module output stored under `/home-index`
+- `meilisearch/` – search indexes persisted by Meilisearch
+- `redis/` – persistent queue data retained between restarts
+
+The Redis volume at `./docker-data/redis` retains module queues between restarts.
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,11 @@ services:
     container_name: home-index
     depends_on:
       - meilisearch
+      - redis
     environment:
       - DEBUG=True
       - MEILISEARCH_HOST=http://meilisearch:7700
+      - REDIS_HOST=http://redis:6379
       - TZ=America/Los_Angeles
     restart: unless-stopped
     volumes:
@@ -25,3 +27,10 @@ services:
       - "7700:7700"
     volumes:
       - ./docker-data/meilisearch:/meili_data
+
+  redis:
+    image: redis:7
+    command: redis-server --loglevel verbose --appendonly yes
+    restart: unless-stopped
+    volumes:
+      - ./docker-data/redis:/data

--- a/features/F1/sync.py
+++ b/features/F1/sync.py
@@ -386,6 +386,17 @@ async def update_meilisearch(
     total_docs_in_meili = await search_index.get_document_count()
     files_logger.info(" * counted %d documents in meilisearch", total_docs_in_meili)
 
+    # Ensure module queues are refreshed immediately after sync
+    if modules_f4.module_values and upserted_docs_by_hash:
+        await asyncio.gather(
+            *[
+                modules_f4.service_module_queue(
+                    mod["name"], docs=upserted_docs_by_hash.values()
+                )
+                for mod in modules_f4.module_values
+            ]
+        )
+
 
 async def sync_documents() -> None:
     try:

--- a/features/F4/ADR.md
+++ b/features/F4/ADR.md
@@ -6,3 +6,9 @@
 - Order and unique IDs of modules are declared via environment variables.
 - Runner loops queue archive-first jobs for mounted drives.
 - Design keeps modules isolated and easily upgradeable.
+
+### 2025-07-21 Redis persistence
+- Docker Compose now runs Redis with `appendonly yes` and a persistent
+  volume so module queues survive restarts.
+- `service_module_queue` accepts an optional list of updated documents to
+  avoid scanning the entire index on single-file updates.

--- a/features/F4/acceptance_tests/docker-compose.yml
+++ b/features/F4/acceptance_tests/docker-compose.yml
@@ -113,6 +113,8 @@ services:
       - ./output:/home-index
   redis:
     image: redis:7
-    command: redis-server --loglevel verbose
+    command: redis-server --loglevel verbose --appendonly yes
     ports:
       - "6379:6379"
+    volumes:
+      - ./output/redis:/data

--- a/features/F4/unit_tests/test_chunk_integration.py
+++ b/features/F4/unit_tests/test_chunk_integration.py
@@ -14,7 +14,7 @@ def test_service_module_queue_processes_segment_content(monkeypatch):
     importlib.reload(search_index)
     importlib.reload(chunking)
 
-    doc = {"id": "file1", "mtime": 1.0, "paths": {"a.txt": 1.0}, "next": ""}
+    doc = {"id": "file1", "mtime": 1.0, "paths": {"a.txt": 1.0}, "next": "mod"}
 
     async def fake_get_jobs(name):
         return [doc]
@@ -119,7 +119,7 @@ def test_service_module_queue_processes_segment_content(monkeypatch):
     monkeypatch.setattr(search_index, "wait_for_meili_idle", fake_wait)
     modules_f4.module_values = []
 
-    result = asyncio.run(modules_f4.service_module_queue("mod", dummy))
+    result = asyncio.run(modules_f4.service_module_queue("mod", dummy, [doc]))
     asyncio.run(modules_f4.process_done_queue(dummy))
     asyncio.run(modules_f4.process_done_queue(dummy))
 
@@ -138,7 +138,7 @@ def test_service_module_queue_handles_update_only(monkeypatch):
     importlib.reload(modules_f4)
     importlib.reload(search_index)
 
-    doc = {"id": "file2", "mtime": 1.0, "paths": {"b.txt": 1.0}, "next": ""}
+    doc = {"id": "file2", "mtime": 1.0, "paths": {"b.txt": 1.0}, "next": "mod"}
 
     async def fake_get_jobs(name):
         return [doc]
@@ -200,7 +200,7 @@ def test_service_module_queue_handles_update_only(monkeypatch):
     monkeypatch.setattr(search_index, "wait_for_meili_idle", dummy_wait)
     modules_f4.module_values = []
 
-    result = asyncio.run(modules_f4.service_module_queue("mod", dummy))
+    result = asyncio.run(modules_f4.service_module_queue("mod", dummy, [doc]))
     asyncio.run(modules_f4.process_done_queue(dummy))
 
     assert result is True
@@ -224,7 +224,7 @@ def test_service_module_queue_processes_content(monkeypatch):
         "id": "file3",
         "mtime": 1.0,
         "paths": {"c.txt": 1.0},
-        "next": "",
+        "next": "mod",
     }
 
     async def fake_get_jobs(name):
@@ -291,7 +291,7 @@ def test_service_module_queue_processes_content(monkeypatch):
     monkeypatch.setattr(search_index, "wait_for_meili_idle", lambda: None)
     modules_f4.module_values = []
 
-    result = asyncio.run(modules_f4.service_module_queue("mod", dummy))
+    result = asyncio.run(modules_f4.service_module_queue("mod", dummy, [doc]))
     asyncio.run(modules_f4.process_done_queue(dummy))
 
     assert result is True
@@ -316,7 +316,7 @@ def test_sync_content_files_generates_chunks(monkeypatch, tmp_path):
         lambda: Path(tmp_path / "meta" / "by-id"),
     )
 
-    doc = {"id": "file4", "paths": {"d.txt": 1.0}, "next": ""}
+    doc = {"id": "file4", "paths": {"d.txt": 1.0}, "next": "mod"}
     docs = {"file4": doc}
     mod_dir = Path(tmp_path / "meta" / "by-id" / "file4" / "mod")
     mod_dir.mkdir(parents=True)

--- a/features/F4/unit_tests/test_queue_order.py
+++ b/features/F4/unit_tests/test_queue_order.py
@@ -1,0 +1,63 @@
+import asyncio
+import importlib
+import json
+
+
+def _reload_modules(monkeypatch):
+    from features.F4 import modules as modules_f4
+
+    importlib.reload(modules_f4)
+    from features.F2 import search_index
+
+    importlib.reload(search_index)
+    monkeypatch.setattr(modules_f4, "module_values", [])
+
+
+def test_archive_files_first(monkeypatch):
+    _reload_modules(monkeypatch)
+    from features.F2 import search_index
+    from features.F4 import modules as modules_f4
+
+    doc_arch = {
+        "id": "1",
+        "paths": {"archive/drive1/b.txt": 1.0},
+        "paths_list": ["archive/drive1/b.txt"],
+        "mtime": 1.0,
+        "next": "mod",
+        "has_archive_paths": True,
+        "offline": False,
+    }
+
+    doc_normal = {
+        "id": "2",
+        "paths": {"a.txt": 1.0},
+        "paths_list": ["a.txt"],
+        "mtime": 1.0,
+        "next": "mod",
+        "has_archive_paths": False,
+        "offline": False,
+    }
+
+    async def fake_get_jobs(name):
+        raise AssertionError("should not call get_all_pending_jobs")
+
+    monkeypatch.setattr(search_index, "get_all_pending_jobs", fake_get_jobs)
+
+    class DummyRedis:
+        def __init__(self):
+            self.storage = {}
+
+        def rpush(self, key, val):
+            self.storage.setdefault(key, []).append(val)
+
+        def lrange(self, key, _start, _end):
+            return self.storage.get(key, [])
+
+    dummy = DummyRedis()
+    result = asyncio.run(
+        modules_f4.service_module_queue("mod", dummy, [doc_normal, doc_arch])
+    )
+    assert result
+    pushed = dummy.storage["mod:check"]
+    assert json.loads(pushed[0])["id"] == "1"
+    assert json.loads(pushed[1])["id"] == "2"

--- a/features/F5/acceptance_tests/docker-compose.yml
+++ b/features/F5/acceptance_tests/docker-compose.yml
@@ -48,6 +48,8 @@ services:
       - ./output:/home-index
   redis:
     image: redis:7
-    command: redis-server --loglevel verbose
+    command: redis-server --loglevel verbose --appendonly yes
     ports:
       - "6379:6379"
+    volumes:
+      - ./output/redis:/data

--- a/features/F6/api.py
+++ b/features/F6/api.py
@@ -208,6 +208,15 @@ async def apply_ops(ops: FileOps) -> None:
         await search_index.delete_chunk_docs_by_file_ids(ids_to_delete)
     if docs_to_upsert or ids_to_delete:
         await search_index.wait_for_meili_idle()
+        if modules_f4.module_values and docs_to_upsert:
+            await asyncio.gather(
+                *[
+                    modules_f4.service_module_queue(
+                        mod["name"], docs=docs_to_upsert.values()
+                    )
+                    for mod in modules_f4.module_values
+                ]
+            )
 
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- mount redis volume for persistence
- propagate redis queue updates in sync and API
- enforce archive-first module queue ordering
- describe running with docker-compose and redis persistence in README
- optimize service_module_queue to accept updated docs directly
- clarify Redis volume path in docs
- explain why `appendonly yes` is recommended
- document docker-data directory contents
- clarify file mount read/write behavior

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ec1405b64832baa9dea88ae49ec94