### PR TITLE
Run acceptance tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,22 +17,10 @@ jobs:
 
       - run: docker-compose -f .devcontainer/docker-compose.yml up --build -d
       - run: docker exec ${REPO}-devcontainer postStart.sh
-      - run: docker exec ${REPO}-devcontainer ./check.sh
 
       - run: docker exec ${REPO}-devcontainer docker build -f Dockerfile -t ${REPO}:ci --build-arg COMMIT_SHA=$(git rev-parse HEAD) .
       - run: docker exec ${REPO}-devcontainer docker build -f features/F4/home_index_module/Dockerfile -t ${REPO}-module:ci --build-arg COMMIT_SHA=$(git rev-parse HEAD) .
 
-      - run: |
-          set -euo pipefail
-          FEATURES=$(ls features | grep '^F')
-          SHA=$(git rev-parse HEAD)
-          for f in $FEATURES; do
-            docker exec \
-              -e IMAGE=${REPO}:ci \
-              -e COMMIT_SHA=${SHA} \
-              -e MODULE_BASE_IMAGE=${REPO}-module:ci \
-              ${REPO}-devcontainer \
-              bash -lc "source venv/bin/activate && pytest -q features/${f}/tests/acceptance/test_acceptance.py"
-          done
+      - run: docker exec -e IMAGE=${REPO}:ci -e MODULE_BASE_IMAGE=${REPO}-module:ci -e COMMIT_SHA=$(git rev-parse HEAD) -e CI=true ${REPO}-devcontainer ./check.sh
 
       - run: docker-compose -f .devcontainer/docker-compose.yml down -v

--- a/check.sh
+++ b/check.sh
@@ -17,7 +17,9 @@ fi
 # Install formatting, linting and test tools if they are not already
 # present. This script is also used by `.devcontainer/postStart.sh` so
 # the dependency list is maintained in one place.
-"$(dirname "$0")/.devcontainer/install_dev_tools.sh"
+if [ "${CI:-}" != "true" ]; then
+  "$(dirname "$0")/.devcontainer/install_dev_tools.sh"
+fi
 
 black --check .
 ruff check .
@@ -25,3 +27,7 @@ mypy --ignore-missing-imports --strict --explicit-package-bases \
   --no-site-packages --exclude 'tests' \
   main.py shared features
 pytest -q features/*/tests/unit
+
+if [ "${CI:-}" = "true" ]; then
+  pytest -q features/*/tests/acceptance
+fi


### PR DESCRIPTION
## Summary
- execute acceptance tests once when CI is true
- remove duplicate CI env variable from workflow
- only install dev tools when not running in CI

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ed7fbb630832ba15140079ceb5552