### PR TITLE
Fix acceptance test discovery and timestamp warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ repo/
 * ONE `features/Fx/tests/acceptance/docker-compose.yml` per feature.
 * Keep all inputs/outputs in `features/Fx/tests/acceptance/{input,output}` dirs.
 * Handle each acceptance scenario from the spec via env vars + input files
-* Each acceptance scenario lives in `features/Fx/tests/acceptance/test_sY.py` with a function named `fXsY`.
+* Each acceptance scenario lives in `features/Fx/tests/acceptance/test_sY.py` with a function named `test_fXsY`.
 * Assert exact user‑facing output, exactly as spec'd (logs, UI, API, exit codes).
 * Do NOT use mocks, stubs, or dummies unless absolutely necessary.
 * On failure output test logs + relevant release‑env container logs.

--- a/features/F1/tests/acceptance/test_acceptance.py
+++ b/features/F1/tests/acceptance/test_acceptance.py
@@ -1,19 +1,19 @@
-from .test_s1 import f1s1
-from .test_s2 import f1s2
-from .test_s3 import f1s3
-from .test_s4 import f1s4
-from .test_s5 import f1s5
-from .test_s6 import f1s6
-from .test_s7 import f1s7
-from .test_s8 import f1s8
+from .test_s1 import test_f1s1
+from .test_s2 import test_f1s2
+from .test_s3 import test_f1s3
+from .test_s4 import test_f1s4
+from .test_s5 import test_f1s5
+from .test_s6 import test_f1s6
+from .test_s7 import test_f1s7
+from .test_s8 import test_f1s8
 
 __all__ = [
-    "f1s1",
-    "f1s2",
-    "f1s3",
-    "f1s4",
-    "f1s5",
-    "f1s6",
-    "f1s7",
-    "f1s8",
+    "test_f1s1",
+    "test_f1s2",
+    "test_f1s3",
+    "test_f1s4",
+    "test_f1s5",
+    "test_f1s6",
+    "test_f1s7",
+    "test_f1s8",
 ]

--- a/features/F1/tests/acceptance/test_s1.py
+++ b/features/F1/tests/acceptance/test_s1.py
@@ -11,7 +11,7 @@ from .helpers import (
 )
 
 
-def f1s1(tmp_path: Path) -> None:
+def test_f1s1(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     cron = "* * * * * *"

--- a/features/F1/tests/acceptance/test_s2.py
+++ b/features/F1/tests/acceptance/test_s2.py
@@ -12,7 +12,7 @@ from .helpers import (
 )
 
 
-def f1s2(tmp_path: Path) -> None:
+def test_f1s2(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     cron = "* * * * * *"

--- a/features/F1/tests/acceptance/test_s3.py
+++ b/features/F1/tests/acceptance/test_s3.py
@@ -12,7 +12,7 @@ from .helpers import (
 )
 
 
-def f1s3(tmp_path: Path) -> None:
+def test_f1s3(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     cron = "* * * * * *"

--- a/features/F1/tests/acceptance/test_s4.py
+++ b/features/F1/tests/acceptance/test_s4.py
@@ -12,7 +12,7 @@ from .helpers import (
 )
 
 
-def f1s4(tmp_path: Path) -> None:
+def test_f1s4(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     cron = "*/2 * * * * *"

--- a/features/F1/tests/acceptance/test_s5.py
+++ b/features/F1/tests/acceptance/test_s5.py
@@ -13,7 +13,7 @@ from .helpers import (
 )
 
 
-def f1s5(tmp_path: Path) -> None:
+def test_f1s5(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     cron = "* * * * * *"

--- a/features/F1/tests/acceptance/test_s6.py
+++ b/features/F1/tests/acceptance/test_s6.py
@@ -13,7 +13,7 @@ from .helpers import (
 )
 
 
-def f1s6(tmp_path: Path) -> None:
+def test_f1s6(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     cron1 = "* * * * * *"

--- a/features/F1/tests/acceptance/test_s7.py
+++ b/features/F1/tests/acceptance/test_s7.py
@@ -12,7 +12,7 @@ from .helpers import (
 )
 
 
-def f1s7(tmp_path: Path) -> None:
+def test_f1s7(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     cron = "* * * * * *"

--- a/features/F1/tests/acceptance/test_s8.py
+++ b/features/F1/tests/acceptance/test_s8.py
@@ -10,7 +10,7 @@ from .helpers import (
 )
 
 
-def f1s8(tmp_path: Path) -> None:
+def test_f1s8(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     _write_env(env_file, "bad cron")

--- a/features/F2/tests/acceptance/test_acceptance.py
+++ b/features/F2/tests/acceptance/test_acceptance.py
@@ -1,23 +1,23 @@
-from .test_s1 import f2s1
-from .test_s2 import f2s2
-from .test_s3 import f2s3
-from .test_s4 import f2s4
-from .test_s5 import f2s5
-from .test_s6 import f2s6
-from .test_s7 import f2s7
-from .test_s8 import f2s8
-from .test_s9 import f2s9
-from .test_s10 import f2s10
+from .test_s1 import test_f2s1
+from .test_s2 import test_f2s2
+from .test_s3 import test_f2s3
+from .test_s4 import test_f2s4
+from .test_s5 import test_f2s5
+from .test_s6 import test_f2s6
+from .test_s7 import test_f2s7
+from .test_s8 import test_f2s8
+from .test_s9 import test_f2s9
+from .test_s10 import test_f2s10
 
 __all__ = [
-    "f2s1",
-    "f2s2",
-    "f2s3",
-    "f2s4",
-    "f2s5",
-    "f2s6",
-    "f2s7",
-    "f2s8",
-    "f2s9",
-    "f2s10",
+    "test_f2s1",
+    "test_f2s2",
+    "test_f2s3",
+    "test_f2s4",
+    "test_f2s5",
+    "test_f2s6",
+    "test_f2s7",
+    "test_f2s8",
+    "test_f2s9",
+    "test_f2s10",
 ]

--- a/features/F2/tests/acceptance/test_s1.py
+++ b/features/F2/tests/acceptance/test_s1.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs
 from .helpers import _run_once
 
 
-def f2s1(tmp_path: Path) -> None:
+def test_f2s1(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         by_id_dir, by_path_dir, _, _, uniq_docs = _run_once(

--- a/features/F2/tests/acceptance/test_s10.py
+++ b/features/F2/tests/acceptance/test_s10.py
@@ -8,7 +8,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once, _sync
 
 
-def f2s10(tmp_path: Path) -> None:
+def test_f2s10(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         _, _, _, _, uniq_docs = _run_once(compose_file, workdir, output_dir)

--- a/features/F2/tests/acceptance/test_s2.py
+++ b/features/F2/tests/acceptance/test_s2.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs
 from .helpers import _run_once
 
 
-def f2s2(tmp_path: Path) -> None:
+def test_f2s2(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         _, _, info, dup_docs, uniq_docs = _run_once(compose_file, workdir, output_dir)

--- a/features/F2/tests/acceptance/test_s3.py
+++ b/features/F2/tests/acceptance/test_s3.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f2s3(tmp_path: Path) -> None:
+def test_f2s3(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         _run_once(compose_file, workdir, output_dir)

--- a/features/F2/tests/acceptance/test_s4.py
+++ b/features/F2/tests/acceptance/test_s4.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f2s4(tmp_path: Path) -> None:
+def test_f2s4(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         _, _, info, _, uniq_docs = _run_once(compose_file, workdir, output_dir)

--- a/features/F2/tests/acceptance/test_s5.py
+++ b/features/F2/tests/acceptance/test_s5.py
@@ -8,7 +8,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once, _sync
 
 
-def f2s5(tmp_path: Path) -> None:
+def test_f2s5(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         by_id_dir, by_path_dir, _, _, uniq_docs = _run_once(

--- a/features/F2/tests/acceptance/test_s6.py
+++ b/features/F2/tests/acceptance/test_s6.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once, _sync
 
 
-def f2s6(tmp_path: Path) -> None:
+def test_f2s6(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         _, by_path_dir, _, dup_docs, _ = _run_once(compose_file, workdir, output_dir)

--- a/features/F2/tests/acceptance/test_s7.py
+++ b/features/F2/tests/acceptance/test_s7.py
@@ -8,7 +8,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once, _sync
 
 
-def f2s7(tmp_path: Path) -> None:
+def test_f2s7(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         by_id_dir, by_path_dir, _, _, uniq_docs = _run_once(

--- a/features/F2/tests/acceptance/test_s8.py
+++ b/features/F2/tests/acceptance/test_s8.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once, _sync
 
 
-def f2s8(tmp_path: Path) -> None:
+def test_f2s8(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         by_id_dir, by_path_dir, _, dup_docs, _ = _run_once(

--- a/features/F2/tests/acceptance/test_s9.py
+++ b/features/F2/tests/acceptance/test_s9.py
@@ -8,7 +8,7 @@ from shared import compose, compose_paths, dump_logs
 from .helpers import _run_once, _sync
 
 
-def f2s9(tmp_path: Path) -> None:
+def test_f2s9(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     try:
         by_id_dir, by_path_dir, _, _, _ = _run_once(compose_file, workdir, output_dir)

--- a/features/F3/archive.py
+++ b/features/F3/archive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping
 
@@ -114,7 +114,9 @@ def update_drive_markers(docs: Mapping[str, Mapping[str, Any]]) -> None:
             if drive not in drives_referenced:
                 marker.unlink()
 
-    timestamp = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    timestamp = (
+        datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
     for drive in drives_referenced:
         pending = pending_map.get(drive, False)
         if drive in drives_present or pending:

--- a/features/F3/tests/acceptance/test_acceptance.py
+++ b/features/F3/tests/acceptance/test_acceptance.py
@@ -1,25 +1,25 @@
-from .test_s1 import f3s1
-from .test_s2 import f3s2
-from .test_s3 import f3s3
-from .test_s4 import f3s4
-from .test_s5 import f3s5
-from .test_s6 import f3s6
-from .test_s7 import f3s7
-from .test_s8 import f3s8
-from .test_s9 import f3s9
-from .test_s10 import f3s10
-from .test_s11 import f3s11
+from .test_s1 import test_f3s1
+from .test_s2 import test_f3s2
+from .test_s3 import test_f3s3
+from .test_s4 import test_f3s4
+from .test_s5 import test_f3s5
+from .test_s6 import test_f3s6
+from .test_s7 import test_f3s7
+from .test_s8 import test_f3s8
+from .test_s9 import test_f3s9
+from .test_s10 import test_f3s10
+from .test_s11 import test_f3s11
 
 __all__ = [
-    "f3s1",
-    "f3s2",
-    "f3s3",
-    "f3s4",
-    "f3s5",
-    "f3s6",
-    "f3s7",
-    "f3s8",
-    "f3s9",
-    "f3s10",
-    "f3s11",
+    "test_f3s1",
+    "test_f3s2",
+    "test_f3s3",
+    "test_f3s4",
+    "test_f3s5",
+    "test_f3s6",
+    "test_f3s7",
+    "test_f3s8",
+    "test_f3s9",
+    "test_f3s10",
+    "test_f3s11",
 ]

--- a/features/F3/tests/acceptance/test_s1.py
+++ b/features/F3/tests/acceptance/test_s1.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s1(tmp_path: Path) -> None:
+def test_f3s1(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
 
     def setup(input_dir: Path) -> None:

--- a/features/F3/tests/acceptance/test_s10.py
+++ b/features/F3/tests/acceptance/test_s10.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once, _run_sync
 
 
-def f3s10(tmp_path: Path) -> None:
+def test_f3s10(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
 
     def setup(input_dir: Path) -> None:

--- a/features/F3/tests/acceptance/test_s11.py
+++ b/features/F3/tests/acceptance/test_s11.py
@@ -8,7 +8,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s11(tmp_path: Path) -> None:
+def test_f3s11(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
 
     def setup(input_dir: Path) -> None:

--- a/features/F3/tests/acceptance/test_s2.py
+++ b/features/F3/tests/acceptance/test_s2.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s2(tmp_path: Path) -> None:
+def test_f3s2(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     ts = "2025-01-01T00:00:00Z"
 

--- a/features/F3/tests/acceptance/test_s3.py
+++ b/features/F3/tests/acceptance/test_s3.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s3(tmp_path: Path) -> None:
+def test_f3s3(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     ts = "2025-01-01T00:00:00Z"
 

--- a/features/F3/tests/acceptance/test_s4.py
+++ b/features/F3/tests/acceptance/test_s4.py
@@ -8,7 +8,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s4(tmp_path: Path) -> None:
+def test_f3s4(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     ts = "2025-01-01T00:00:00Z"
 

--- a/features/F3/tests/acceptance/test_s5.py
+++ b/features/F3/tests/acceptance/test_s5.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s5(tmp_path: Path) -> None:
+def test_f3s5(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
 
     def setup(input_dir: Path) -> None:

--- a/features/F3/tests/acceptance/test_s6.py
+++ b/features/F3/tests/acceptance/test_s6.py
@@ -8,7 +8,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s6(tmp_path: Path) -> None:
+def test_f3s6(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
 
     def setup(input_dir: Path) -> None:

--- a/features/F3/tests/acceptance/test_s7.py
+++ b/features/F3/tests/acceptance/test_s7.py
@@ -9,7 +9,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s7(tmp_path: Path) -> None:
+def test_f3s7(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     ts = "2025-01-01T00:00:00Z"
 

--- a/features/F3/tests/acceptance/test_s8.py
+++ b/features/F3/tests/acceptance/test_s8.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs
 from .helpers import _run_once
 
 
-def f3s8(tmp_path: Path) -> None:
+def test_f3s8(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
 
     def setup(input_dir: Path) -> None:

--- a/features/F3/tests/acceptance/test_s9.py
+++ b/features/F3/tests/acceptance/test_s9.py
@@ -7,7 +7,7 @@ from shared import compose, compose_paths, dump_logs, search_meili
 from .helpers import _run_once
 
 
-def f3s9(tmp_path: Path) -> None:
+def test_f3s9(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
 
     def setup(input_dir: Path) -> None:

--- a/features/F4/tests/acceptance/test_acceptance.py
+++ b/features/F4/tests/acceptance/test_acceptance.py
@@ -1,33 +1,33 @@
-from .test_s1 import f4s1
-from .test_s2 import f4s2
-from .test_s3 import f4s3
-from .test_s4 import f4s4
-from .test_s5 import f4s5
-from .test_s6 import f4s6
-from .test_s7 import f4s7
-from .test_s8 import f4s8
-from .test_s9 import f4s9
-from .test_s10 import f4s10
-from .test_s11 import f4s11
-from .test_s12 import f4s12
-from .test_s13 import f4s13
-from .test_s14 import f4s14
-from .test_s15 import f4s15
+from .test_s1 import test_f4s1
+from .test_s2 import test_f4s2
+from .test_s3 import test_f4s3
+from .test_s4 import test_f4s4
+from .test_s5 import test_f4s5
+from .test_s6 import test_f4s6
+from .test_s7 import test_f4s7
+from .test_s8 import test_f4s8
+from .test_s9 import test_f4s9
+from .test_s10 import test_f4s10
+from .test_s11 import test_f4s11
+from .test_s12 import test_f4s12
+from .test_s13 import test_f4s13
+from .test_s14 import test_f4s14
+from .test_s15 import test_f4s15
 
 __all__ = [
-    "f4s1",
-    "f4s2",
-    "f4s3",
-    "f4s4",
-    "f4s5",
-    "f4s6",
-    "f4s7",
-    "f4s8",
-    "f4s9",
-    "f4s10",
-    "f4s11",
-    "f4s12",
-    "f4s13",
-    "f4s14",
-    "f4s15",
+    "test_f4s1",
+    "test_f4s2",
+    "test_f4s3",
+    "test_f4s4",
+    "test_f4s5",
+    "test_f4s6",
+    "test_f4s7",
+    "test_f4s8",
+    "test_f4s9",
+    "test_f4s10",
+    "test_f4s11",
+    "test_f4s12",
+    "test_f4s13",
+    "test_f4s14",
+    "test_f4s15",
 ]

--- a/features/F4/tests/acceptance/test_s1.py
+++ b/features/F4/tests/acceptance/test_s1.py
@@ -7,7 +7,7 @@ from shared import compose_paths
 from .helpers import _run_once
 
 
-def f4s1(tmp_path: Path) -> None:
+def test_f4s1(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     drive = workdir / "input" / "archive" / "drive1"

--- a/features/F4/tests/acceptance/test_s10.py
+++ b/features/F4/tests/acceptance/test_s10.py
@@ -8,7 +8,7 @@ from shared import compose_paths
 from .helpers import _run_once, _get_doc_id, _run_again
 
 
-def f4s10() -> None:
+def test_f4s10() -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = Path(tempfile.mkdtemp()) / ".env"
     _run_once(compose_file, workdir, output_dir, env_file)

--- a/features/F4/tests/acceptance/test_s11.py
+++ b/features/F4/tests/acceptance/test_s11.py
@@ -7,7 +7,7 @@ from shared import compose_paths, search_meili
 from .helpers import _run_uid_mismatch
 
 
-def f4s11(tmp_path: Path) -> None:
+def test_f4s11(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     doc_id = _run_uid_mismatch(compose_file, workdir, output_dir, env_file)

--- a/features/F4/tests/acceptance/test_s12.py
+++ b/features/F4/tests/acceptance/test_s12.py
@@ -9,7 +9,7 @@ from shared import compose, compose_paths, wait_for
 from .helpers import _container_status
 
 
-def f4s12(tmp_path: Path) -> None:
+def test_f4s12(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     env_file.write_text(

--- a/features/F4/tests/acceptance/test_s13.py
+++ b/features/F4/tests/acceptance/test_s13.py
@@ -7,7 +7,7 @@ from shared import compose_paths
 from .helpers import _run_crash_isolation
 
 
-def f4s13(tmp_path: Path) -> None:
+def test_f4s13(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     doc_id, logs = _run_crash_isolation(compose_file, workdir, output_dir, env_file)

--- a/features/F4/tests/acceptance/test_s14.py
+++ b/features/F4/tests/acceptance/test_s14.py
@@ -8,7 +8,7 @@ from shared import compose_paths
 from .helpers import _run_share_group_rotation
 
 
-def f4s14() -> None:
+def test_f4s14() -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = Path(tempfile.mkdtemp()) / ".env"
     logs_example, logs_timeout = _run_share_group_rotation(

--- a/features/F4/tests/acceptance/test_s15.py
+++ b/features/F4/tests/acceptance/test_s15.py
@@ -7,7 +7,7 @@ from shared import compose_paths, search_meili, search_chunks
 from .helpers import _run_once, _get_doc_id
 
 
-def f4s15(tmp_path: Path) -> None:
+def test_f4s15(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     _run_once(compose_file, workdir, output_dir, env_file)

--- a/features/F4/tests/acceptance/test_s2.py
+++ b/features/F4/tests/acceptance/test_s2.py
@@ -7,7 +7,7 @@ from shared import compose_paths
 from .helpers import _run_once
 
 
-def f4s2(tmp_path: Path) -> None:
+def test_f4s2(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     drive = workdir / "input" / "archive" / "drive1"

--- a/features/F4/tests/acceptance/test_s3.py
+++ b/features/F4/tests/acceptance/test_s3.py
@@ -7,7 +7,7 @@ from shared import compose_paths
 from .helpers import _run_remove_drive_mid, _run_again
 
 
-def f4s3(tmp_path: Path) -> None:
+def test_f4s3(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     drive = workdir / "input" / "archive" / "drive1"

--- a/features/F4/tests/acceptance/test_s4.py
+++ b/features/F4/tests/acceptance/test_s4.py
@@ -8,7 +8,7 @@ from shared import compose_paths
 from .helpers import _run_once, _get_doc_id, _run_add_module
 
 
-def f4s4() -> None:
+def test_f4s4() -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_path = Path(tempfile.mkdtemp()) / ".env"
     _run_once(compose_file, workdir, output_dir, env_path)

--- a/features/F4/tests/acceptance/test_s5.py
+++ b/features/F4/tests/acceptance/test_s5.py
@@ -9,7 +9,7 @@ from .helpers import _run_once
 import pytest
 
 
-def f4s5() -> None:
+def test_f4s5() -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     (workdir / "input" / "Foo-status-ready").write_text("x")
     env_file = Path(tempfile.mkdtemp()) / ".env"

--- a/features/F4/tests/acceptance/test_s6.py
+++ b/features/F4/tests/acceptance/test_s6.py
@@ -7,7 +7,7 @@ from shared import compose_paths
 from .helpers import _run_files
 
 
-def f4s6(tmp_path: Path) -> None:
+def test_f4s6(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     drive = workdir / "input" / "archive" / "drive1"

--- a/features/F4/tests/acceptance/test_s7.py
+++ b/features/F4/tests/acceptance/test_s7.py
@@ -7,7 +7,7 @@ from shared import compose_paths, search_meili
 from .helpers import _run_once, _get_doc_id, _run_add_module
 
 
-def f4s7(tmp_path: Path) -> None:
+def test_f4s7(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     _run_once(compose_file, workdir, output_dir, env_file)

--- a/features/F4/tests/acceptance/test_s8.py
+++ b/features/F4/tests/acceptance/test_s8.py
@@ -7,7 +7,7 @@ from shared import compose_paths
 from .helpers import _run_timeout
 
 
-def f4s8(tmp_path: Path) -> None:
+def test_f4s8(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     _run_timeout(compose_file, workdir, output_dir, env_file)

--- a/features/F4/tests/acceptance/test_s9.py
+++ b/features/F4/tests/acceptance/test_s9.py
@@ -7,7 +7,7 @@ from shared import compose_paths
 from .helpers import _run_check_timeout
 
 
-def f4s9(tmp_path: Path) -> None:
+def test_f4s9(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     _run_check_timeout(compose_file, workdir, output_dir, env_file)

--- a/features/F5/tests/acceptance/test_acceptance.py
+++ b/features/F5/tests/acceptance/test_acceptance.py
@@ -1,23 +1,23 @@
-from .test_s1 import f5s1
-from .test_s2 import f5s2
-from .test_s3 import f5s3
-from .test_s4 import f5s4
-from .test_s5 import f5s5
-from .test_s6 import f5s6
-from .test_s7 import f5s7
-from .test_s8 import f5s8
-from .test_s9 import f5s9
-from .test_s10 import f5s10
+from .test_s1 import test_f5s1
+from .test_s2 import test_f5s2
+from .test_s3 import test_f5s3
+from .test_s4 import test_f5s4
+from .test_s5 import test_f5s5
+from .test_s6 import test_f5s6
+from .test_s7 import test_f5s7
+from .test_s8 import test_f5s8
+from .test_s9 import test_f5s9
+from .test_s10 import test_f5s10
 
 __all__ = [
-    "f5s1",
-    "f5s2",
-    "f5s3",
-    "f5s4",
-    "f5s5",
-    "f5s6",
-    "f5s7",
-    "f5s8",
-    "f5s9",
-    "f5s10",
+    "test_f5s1",
+    "test_f5s2",
+    "test_f5s3",
+    "test_f5s4",
+    "test_f5s5",
+    "test_f5s6",
+    "test_f5s7",
+    "test_f5s8",
+    "test_f5s9",
+    "test_f5s10",
 ]

--- a/features/F5/tests/acceptance/test_s1.py
+++ b/features/F5/tests/acceptance/test_s1.py
@@ -8,7 +8,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s1(tmp_path: Path) -> None:
+def test_f5s1(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s10.py
+++ b/features/F5/tests/acceptance/test_s10.py
@@ -15,7 +15,7 @@ from .helpers import (
 from features.F2 import duplicate_finder
 
 
-def f5s10(tmp_path: Path) -> None:
+def test_f5s10(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s2.py
+++ b/features/F5/tests/acceptance/test_s2.py
@@ -8,7 +8,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s2(tmp_path: Path) -> None:
+def test_f5s2(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s3.py
+++ b/features/F5/tests/acceptance/test_s3.py
@@ -8,7 +8,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s3(tmp_path: Path) -> None:
+def test_f5s3(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s4.py
+++ b/features/F5/tests/acceptance/test_s4.py
@@ -9,7 +9,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s4(tmp_path: Path) -> None:
+def test_f5s4(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s5.py
+++ b/features/F5/tests/acceptance/test_s5.py
@@ -15,7 +15,7 @@ from .helpers import (
 from features.F2 import duplicate_finder
 
 
-def f5s5(tmp_path: Path) -> None:
+def test_f5s5(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s6.py
+++ b/features/F5/tests/acceptance/test_s6.py
@@ -9,7 +9,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s6(tmp_path: Path) -> None:
+def test_f5s6(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s7.py
+++ b/features/F5/tests/acceptance/test_s7.py
@@ -9,7 +9,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s7(tmp_path: Path) -> None:
+def test_f5s7(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s8.py
+++ b/features/F5/tests/acceptance/test_s8.py
@@ -9,7 +9,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s8(tmp_path: Path) -> None:
+def test_f5s8(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F5/tests/acceptance/test_s9.py
+++ b/features/F5/tests/acceptance/test_s9.py
@@ -9,7 +9,7 @@ from .helpers import prepare_dirs, start, stop, write_env, wait_initial
 from features.F2 import duplicate_finder
 
 
-def f5s9(tmp_path: Path) -> None:
+def test_f5s9(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     prepare_dirs(workdir, output_dir)

--- a/features/F6/tests/acceptance/test_acceptance.py
+++ b/features/F6/tests/acceptance/test_acceptance.py
@@ -1,13 +1,13 @@
-from .test_s1 import f6s1
-from .test_s2 import f6s2
-from .test_s3 import f6s3
-from .test_s4 import f6s4
-from .test_s5 import f6s5
+from .test_s1 import test_f6s1
+from .test_s2 import test_f6s2
+from .test_s3 import test_f6s3
+from .test_s4 import test_f6s4
+from .test_s5 import test_f6s5
 
 __all__ = [
-    "f6s1",
-    "f6s2",
-    "f6s3",
-    "f6s4",
-    "f6s5",
+    "test_f6s1",
+    "test_f6s2",
+    "test_f6s3",
+    "test_f6s4",
+    "test_f6s5",
 ]

--- a/features/F6/tests/acceptance/test_s1.py
+++ b/features/F6/tests/acceptance/test_s1.py
@@ -8,7 +8,7 @@ from shared import compose_paths, dump_logs, search_meili, wait_for
 from .helpers import put_file, start, stop
 
 
-def f6s1(tmp_path: Path) -> None:
+def test_f6s1(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     start(compose_file, workdir, output_dir, env_file)

--- a/features/F6/tests/acceptance/test_s2.py
+++ b/features/F6/tests/acceptance/test_s2.py
@@ -9,7 +9,7 @@ from shared import compose_paths, dump_logs, search_meili, wait_for
 from .helpers import post_ops, put_file, start, stop
 
 
-def f6s2(tmp_path: Path) -> None:
+def test_f6s2(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     start(compose_file, workdir, output_dir, env_file)

--- a/features/F6/tests/acceptance/test_s3.py
+++ b/features/F6/tests/acceptance/test_s3.py
@@ -8,7 +8,7 @@ from shared import compose_paths, dump_logs, search_meili, wait_for
 from .helpers import post_ops, put_file, start, stop
 
 
-def f6s3(tmp_path: Path) -> None:
+def test_f6s3(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     start(compose_file, workdir, output_dir, env_file)

--- a/features/F6/tests/acceptance/test_s4.py
+++ b/features/F6/tests/acceptance/test_s4.py
@@ -9,7 +9,7 @@ from shared import compose_paths, dump_logs, search_meili, wait_for
 from .helpers import post_ops, put_file, start, stop
 
 
-def f6s4(tmp_path: Path) -> None:
+def test_f6s4(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     start(compose_file, workdir, output_dir, env_file)

--- a/features/F6/tests/acceptance/test_s5.py
+++ b/features/F6/tests/acceptance/test_s5.py
@@ -9,7 +9,7 @@ from shared import compose_paths, dump_logs, search_meili, wait_for
 from .helpers import move_dav, put_file, start, stop
 
 
-def f6s5(tmp_path: Path) -> None:
+def test_f6s5(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
     start(compose_file, workdir, output_dir, env_file)


### PR DESCRIPTION
## Summary
- ensure pytest discovers acceptance scenarios by prefixing functions with `test_`
- specify acceptance test naming convention in `AGENTS.md`
- use timezone-aware `datetime` in archive marker logic

## Testing
- `./check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ef3a985b8832bb803a33a1869c5ec