### PR TITLE
Quiet CI docker output

### DIFF
--- a/.devcontainer/quiet.sh
+++ b/.devcontainer/quiet.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+DESC="$1"; shift
+LOGFILE="$(mktemp)"
+
+# Print start message
+echo "$DESC started"
+
+# Run command, capture output
+if "$@" >"$LOGFILE" 2>&1; then
+    grep -iE '(warning|error)' "$LOGFILE" >&2 || true
+    echo "$DESC completed successfully"
+else
+    echo "$DESC failed" >&2
+    cat "$LOGFILE" >&2
+    exit 1
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,15 @@ jobs:
 
       - name: Install docker-compose
         run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
+          ./.devcontainer/quiet.sh "apt-get update" sudo apt-get update
+          ./.devcontainer/quiet.sh "install docker-compose" sudo apt-get install -y docker-compose
 
-      - run: docker-compose -f .devcontainer/docker-compose.yml up --build -d
-      - run: docker exec ${REPO}-devcontainer postStart.sh
+      - run: ./.devcontainer/quiet.sh "docker-compose up" docker-compose -f .devcontainer/docker-compose.yml up --build -d
+      - run: ./.devcontainer/quiet.sh "postStart.sh" docker exec ${REPO}-devcontainer postStart.sh
 
-      - run: docker exec ${REPO}-devcontainer docker build -f Dockerfile -t ${REPO}:ci --build-arg COMMIT_SHA=$(git rev-parse HEAD) .
-      - run: docker exec ${REPO}-devcontainer docker build -f features/F4/home_index_module/Dockerfile -t ${REPO}-module:ci --build-arg COMMIT_SHA=$(git rev-parse HEAD) .
+      - run: ./.devcontainer/quiet.sh "build main image" docker exec ${REPO}-devcontainer docker build -f Dockerfile -t ${REPO}:ci --build-arg COMMIT_SHA=$(git rev-parse HEAD) .
+      - run: ./.devcontainer/quiet.sh "build module image" docker exec ${REPO}-devcontainer docker build -f features/F4/home_index_module/Dockerfile -t ${REPO}-module:ci --build-arg COMMIT_SHA=$(git rev-parse HEAD) .
 
       - run: docker exec -e IMAGE=${REPO}:ci -e MODULE_BASE_IMAGE=${REPO}-module:ci -e COMMIT_SHA=$(git rev-parse HEAD) -e CI=true ${REPO}-devcontainer ./check.sh
 
-      - run: docker-compose -f .devcontainer/docker-compose.yml down -v
+      - run: ./.devcontainer/quiet.sh "docker-compose down" docker-compose -f .devcontainer/docker-compose.yml down -v


### PR DESCRIPTION
## Summary
- relocate quiet.sh to .devcontainer directory
- call script from new location in test workflow
- silence apt-get operations via quiet.sh

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f01b78b2c832ba09d278822880540