### PR TITLE
Fix acceptance log dump order

### DIFF
--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -13,12 +13,21 @@ from typing import Any, Callable
 
 
 def dump_logs(compose_file: Path, workdir: Path) -> None:
-    """Print logs from all compose containers."""
-    subprocess.run(
-        ["docker", "compose", "-f", str(compose_file), "logs", "--no-color"],
-        cwd=workdir,
-        check=False,
-    )
+    """Print logs from all compose containers in service order."""
+    for service in ("home-index", "meilisearch", "redis"):
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                str(compose_file),
+                "logs",
+                "--no-color",
+                service,
+            ],
+            cwd=workdir,
+            check=False,
+        )
     sys.stdout.flush()
 
 


### PR DESCRIPTION
## Summary
- ensure container logs are printed in a stable order

## Testing
- `./check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f0f28ba54832ba2d16ab1523b1685