### PR TITLE
Fix CI variable usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,8 @@ jobs:
         run: |
           docker exec -e IMAGE=${REPO}:ci \
             -e MODULE_BASE_IMAGE=${REPO}-module:ci \
-            -e COMMIT_SHA=$(git rev-parse HEAD) -e CI=true \
+            -e COMMIT_SHA=$(git rev-parse HEAD) \
+            -e GITHUB_ACTIONS \
             ${REPO}-devcontainer ./check.sh
 
       - name: Stop dev-container

--- a/check.sh
+++ b/check.sh
@@ -43,7 +43,7 @@ for venv in "venv" "../venv"; do
   [[ -f "$venv/bin/activate" ]] && source "$venv/bin/activate" && break
 done
 
-if [[ ${CI:-false} != "true" ]]; then
+if [[ ${GITHUB_ACTIONS:-false} != "true" ]]; then
   run "$SCRIPT_DIR/.devcontainer/install_dev_tools.sh"
 fi
 
@@ -60,7 +60,7 @@ run pytest -q features/*/tests/unit
 ###############################################################################
 # Acceptance tests (CI only)
 ###############################################################################
-if [[ ${CI:-false} == "true" ]]; then
+if [[ ${GITHUB_ACTIONS:-false} == "true" ]]; then
   mapfile -t test_files < <(
     find features -path '*/tests/acceptance/test_*.py' | sort -V
   )


### PR DESCRIPTION
## Summary
- rely on `GITHUB_ACTIONS` to detect CI in `check.sh`
- drop custom `CI` env from workflow and forward `GITHUB_ACTIONS`

## Testing
- `bash check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f14e096f0832ba33ca62e45dad306