### PR TITLE
Use GitHub Actions env in CI checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,8 @@ jobs:
         run: |
           docker exec -e IMAGE=${REPO}:ci \
             -e MODULE_BASE_IMAGE=${REPO}-module:ci \
-            -e COMMIT_SHA=$(git rev-parse HEAD) -e CI=true \
+            -e COMMIT_SHA=$(git rev-parse HEAD) \
+            -e GITHUB_ACTIONS \
             ${REPO}-devcontainer ./check.sh
 
       - name: Stop dev-container

--- a/check.sh
+++ b/check.sh
@@ -47,7 +47,7 @@ for venv in "venv" "../venv"; do
   [[ -f "$venv/bin/activate" ]] && source "$venv/bin/activate" && break
 done
 
-if [[ ${CI:-false} != "true" ]]; then
+if [[ ${GITHUB_ACTIONS:-false} != "true" ]]; then
   run "$SCRIPT_DIR/.devcontainer/install_dev_tools.sh"
 fi
 
@@ -67,7 +67,7 @@ run_named "pytest unit (-q)" \
 ###############################################################################
 # Acceptance tests (CI only)
 ###############################################################################
-if [[ ${CI:-false} == "true" ]]; then
+if [[ ${GITHUB_ACTIONS:-false} == "true" ]]; then
   mapfile -t test_files < <(
     find features -path '*/tests/acceptance/test_*.py' | sort -V
   )


### PR DESCRIPTION
## Summary
- remove custom CI variable from test workflow
- check GitHub Actions env var in `check.sh`
- pass `GITHUB_ACTIONS` env through docker exec

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687f18742b94832bbd9b6dfa87023a56