### PR TITLE
Fix CI log check by improving error output

### DIFF
--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, Callable
@@ -66,8 +67,19 @@ def search_meili(
             docs = payload.get("hits") or payload.get("results") or []
             if docs:
                 return list(docs)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="ignore")
+            print(
+                f"search_meili(index={index!r}, filter={filter_expr!r}) HTTP {e.code}: {body}",
+                file=sys.stderr,
+                flush=True,
+            )
         except Exception as e:
-            print(f"search_meili error: {e}", file=sys.stderr)
+            print(
+                f"search_meili(index={index!r}, filter={filter_expr!r}) error: {type(e).__name__}: {e}",
+                file=sys.stderr,
+                flush=True,
+            )
         if time.time() > deadline:
             raise AssertionError(
                 f"Timed out waiting for search results for: {filter_expr}"
@@ -102,8 +114,19 @@ def search_chunks(
             docs = payload.get("hits") or payload.get("results") or []
             if docs:
                 return list(docs)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="ignore")
+            print(
+                f"search_chunks(filter={filter_expr!r}, query={query!r}) HTTP {e.code}: {body}",
+                file=sys.stderr,
+                flush=True,
+            )
         except Exception as e:
-            print(f"search_chunks error: {e}", file=sys.stderr)
+            print(
+                f"search_chunks(filter={filter_expr!r}, query={query!r}) error: {type(e).__name__}: {e}",
+                file=sys.stderr,
+                flush=True,
+            )
         if time.time() > deadline:
             raise AssertionError("Timed out waiting for search results")
         time.sleep(0.5)

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -33,13 +33,14 @@ def dump_logs(compose_file: Path, workdir: Path) -> None:
         )
         if result.returncode == 0:
             if result.stdout:
-                print(result.stdout, end="")
+                print(result.stdout, end="", flush=True)
             continue
         if "no such service" in result.stderr.lower():
             continue
         if result.stderr:
-            print(result.stderr, file=sys.stderr, end="")
+            print(result.stderr, file=sys.stderr, end="", flush=True)
     sys.stdout.flush()
+    sys.stderr.flush()
 
 
 def search_meili(
@@ -82,7 +83,7 @@ def search_meili(
             )
         if time.time() > deadline:
             raise AssertionError(
-                f"Timed out waiting for search results for: {filter_expr}"
+                f"Timed out waiting for search results: index={index!r}, filter={filter_expr!r}"
             )
         time.sleep(0.5)
 
@@ -128,7 +129,9 @@ def search_chunks(
                 flush=True,
             )
         if time.time() > deadline:
-            raise AssertionError("Timed out waiting for search results")
+            raise AssertionError(
+                f"Timed out waiting for search results: filter={filter_expr!r}, query={query!r}"
+            )
         time.sleep(0.5)
 
 


### PR DESCRIPTION
## Summary
- improve diagnostics in `search_meili` by logging HTTP errors with more context
- add matching diagnostics to `search_chunks`
- flush diagnostic output to ensure logs appear in CI

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fe7b63360832ba34bee943f536114