### PR TITLE
Improve meili wait logic

### DIFF
--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -5,6 +5,8 @@ from .acceptance import (
     search_meili,
     search_chunks,
     wait_for,
+    wait_for_meili_index,
+    wait_for_meili_idle,
 )
 
 __all__ = [
@@ -14,4 +16,6 @@ __all__ = [
     "compose_paths",
     "compose",
     "wait_for",
+    "wait_for_meili_index",
+    "wait_for_meili_idle",
 ]

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -133,6 +133,7 @@ def search_meili(
     url = f"http://localhost:7700/indexes/{index}/search"
     last_response = ""
     while True:
+        wait_for_meili_idle(timeout=max(1, int(deadline - time.time())))
         try:
             data = {"q": q, "filter": filter_expr}
             req = urllib.request.Request(
@@ -183,6 +184,7 @@ def search_chunks(
     url = "http://localhost:7700/indexes/file_chunks/search"
     last_response = ""
     while True:
+        wait_for_meili_idle(timeout=max(1, int(deadline - time.time())))
         try:
             data = {
                 "q": f"query: {query}",

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -128,12 +128,12 @@ def search_meili(
 ) -> list[dict[str, Any]]:
     """Return documents matching ``filter_expr`` from Meilisearch."""
     wait_for_meili_index(index, timeout=timeout)
-    wait_for_meili_idle(timeout=timeout)
     deadline = time.time() + timeout
     url = f"http://localhost:7700/indexes/{index}/search"
     last_response = ""
     while True:
         try:
+            wait_for_meili_idle(timeout=timeout)
             data = {"q": q, "filter": filter_expr}
             req = urllib.request.Request(
                 url,
@@ -178,12 +178,12 @@ def search_chunks(
 ) -> list[dict[str, Any]]:
     """Return chunk documents matching ``query`` from Meilisearch."""
     wait_for_meili_index("file_chunks", timeout=timeout)
-    wait_for_meili_idle(timeout=timeout)
     deadline = time.time() + timeout
     url = "http://localhost:7700/indexes/file_chunks/search"
     last_response = ""
     while True:
         try:
+            wait_for_meili_idle(timeout=timeout)
             data = {
                 "q": f"query: {query}",
                 "hybrid": {"semanticRatio": 1, "embedder": "e5-small"},

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -133,7 +133,6 @@ def search_meili(
     url = f"http://localhost:7700/indexes/{index}/search"
     last_response = ""
     while True:
-        wait_for_meili_idle(timeout=max(1, int(deadline - time.time())))
         try:
             data = {"q": q, "filter": filter_expr}
             req = urllib.request.Request(
@@ -184,7 +183,6 @@ def search_chunks(
     url = "http://localhost:7700/indexes/file_chunks/search"
     last_response = ""
     while True:
-        wait_for_meili_idle(timeout=max(1, int(deadline - time.time())))
         try:
             data = {
                 "q": f"query: {query}",

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -128,12 +128,12 @@ def search_meili(
 ) -> list[dict[str, Any]]:
     """Return documents matching ``filter_expr`` from Meilisearch."""
     wait_for_meili_index(index, timeout=timeout)
+    wait_for_meili_idle(timeout=timeout)
     deadline = time.time() + timeout
     url = f"http://localhost:7700/indexes/{index}/search"
     last_response = ""
     while True:
         try:
-            wait_for_meili_idle(timeout=timeout)
             data = {"q": q, "filter": filter_expr}
             req = urllib.request.Request(
                 url,
@@ -167,6 +167,7 @@ def search_meili(
             if last_response:
                 msg += f" (last response: {last_response})"
             raise AssertionError(msg)
+        wait_for_meili_idle(timeout=timeout)
         time.sleep(0.5)
 
 
@@ -178,12 +179,12 @@ def search_chunks(
 ) -> list[dict[str, Any]]:
     """Return chunk documents matching ``query`` from Meilisearch."""
     wait_for_meili_index("file_chunks", timeout=timeout)
+    wait_for_meili_idle(timeout=timeout)
     deadline = time.time() + timeout
     url = "http://localhost:7700/indexes/file_chunks/search"
     last_response = ""
     while True:
         try:
-            wait_for_meili_idle(timeout=timeout)
             data = {
                 "q": f"query: {query}",
                 "hybrid": {"semanticRatio": 1, "embedder": "e5-small"},
@@ -222,6 +223,7 @@ def search_chunks(
             if last_response:
                 msg += f" (last response: {last_response})"
             raise AssertionError(msg)
+        wait_for_meili_idle(timeout=timeout)
         time.sleep(0.5)
 
 


### PR DESCRIPTION
## Summary
- wait for index existence before searching meilisearch
- export the new helper `wait_for_meili_index`
- add new synchronous helper `wait_for_meili_idle`
- ensure searches wait for idle meilisearch
- raise error on failed meili tasks
- ignore `index_not_found` errors when waiting for Meilisearch to be idle

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_687fe7b63360832ba34bee943f536114