### PR TITLE
Install pytest-asyncio for acceptance tests

### DIFF
--- a/.devcontainer/install_dev_tools.sh
+++ b/.devcontainer/install_dev_tools.sh
@@ -5,6 +5,7 @@ pip install --quiet \
     ruff==0.12.0 \
     mypy==1.10.0 \
     pytest==8.4.1 \
+    pytest-asyncio==0.23.8 \
     jsonschema==4.24.0 \
     fastapi==0.116.1 \
     asgiwebdav==1.5.0 \

--- a/features/F1/sync.py
+++ b/features/F1/sync.py
@@ -20,6 +20,7 @@ from features.F3 import archive
 from features.F4 import modules as modules_f4
 from features.F5 import chunking
 from shared.logging_config import files_logger
+from shared.acceptance import acceptance_step
 
 INDEX_DIRECTORY = Path(os.environ.get("INDEX_DIRECTORY", "/files"))
 
@@ -401,7 +402,7 @@ async def update_meilisearch(
 async def sync_documents() -> None:
     try:
         files_logger.info("---------------------------------------------------")
-        files_logger.info("start file sync")
+        acceptance_step("start file sync")
         files_logger.info("index previously stored metadata")
         (
             metadata_docs_by_hash,
@@ -434,7 +435,7 @@ async def sync_documents() -> None:
         files_logger.info("commit changes to meilisearch")
         await update_meilisearch(upserted_docs_by_hash, files_docs_by_hash)
         await chunking.sync_content_files(files_docs_by_hash)
-        files_logger.info("completed file sync")
+        acceptance_step("completed file sync")
     except Exception:  # pragma: no cover - unexpected errors
         files_logger.exception("sync failed")
         raise

--- a/features/F1/tests/acceptance/docker-compose.yml
+++ b/features/F1/tests/acceptance/docker-compose.yml
@@ -1,9 +1,13 @@
 services:
   home-index:
     image: ${IMAGE}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - CRON_EXPRESSION=${CRON_EXPRESSION}
       - METADATA_DIRECTORY=/home-index/metadata
+      - TEST=true
+      - TEST_LOG_TARGET=${TEST_LOG_TARGET:-http://host.docker.internal:9020}
       - DEBUG=${DEBUG:-False}
       - DEBUGPY_HOST=${DEBUGPY_HOST:-0.0.0.0}
       - DEBUGPY_PORT=${DEBUGPY_PORT:-5678}

--- a/features/F1/tests/acceptance/helpers.py
+++ b/features/F1/tests/acceptance/helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import shutil
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -57,8 +56,11 @@ def _prepare_dirs(workdir: Path, output_dir: Path, *, with_input: bool = True) -
         input_dir.mkdir()
 
 
-def _write_env(env_file: Path, cron: str) -> None:
-    env_file.write_text(f"CRON_EXPRESSION={cron}\n")
+def _write_env(env_file: Path, cron: str, **extra: str) -> None:
+    lines = [f"CRON_EXPRESSION={cron}"]
+    for k, v in extra.items():
+        lines.append(f"{k}={v}")
+    env_file.write_text("\n".join(lines) + "\n")
 
 
 def _read_start_times(output_dir: Path) -> list[datetime]:
@@ -67,27 +69,3 @@ def _read_start_times(output_dir: Path) -> list[datetime]:
     lines = (output_dir / "files.log").read_text().splitlines()
     stamps = [line.split(" [", 1)[0] for line in lines if "start file sync" in line]
     return [datetime.strptime(s, "%Y-%m-%d %H:%M:%S,%f") for s in stamps]
-
-
-def _wait_for_start_lines(output_dir: Path, count: int) -> list[datetime]:
-    deadline = time.time() + 120
-    while True:
-        times = _read_start_times(output_dir)
-        if len(times) >= count:
-            return times
-        if time.time() > deadline:
-            raise AssertionError("Timed out waiting for sync logs")
-        time.sleep(0.5)
-
-
-def _wait_for_log(output_dir: Path, text: str, start: int = 0) -> int:
-    deadline = time.time() + 120
-    while True:
-        if (output_dir / "files.log").exists():
-            lines = (output_dir / "files.log").read_text().splitlines()
-            for idx, line in enumerate(lines[start:], start=start):
-                if text in line:
-                    return idx
-        if time.time() > deadline:
-            raise AssertionError(f"Timed out waiting for log containing: {text}")
-        time.sleep(0.5)

--- a/features/F1/tests/acceptance/test_s2.py
+++ b/features/F1/tests/acceptance/test_s2.py
@@ -2,36 +2,44 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from shared import compose, compose_paths, dump_logs, wait_for
+from shared import compose, compose_paths, dump_logs
+import pytest
 
-from .helpers import (
-    _write_env,
-    _prepare_dirs,
-    _wait_for_start_lines,
-    _wait_for_log,
-)
+from .helpers import _write_env, _prepare_dirs
+from shared.acceptance import _start_server
+from shared.acceptance import assert_event_sequence
 
 
-def test_f1s2(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_f1s2(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
+    server, host, port = await _start_server()
     cron = "* * * * * *"
-    _write_env(env_file, cron)
+    _write_env(env_file, cron, TEST="true", TEST_LOG_TARGET=f"http://{host}:{port}")
     _prepare_dirs(workdir, output_dir)
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    writer = None
     try:
-        _wait_for_start_lines(output_dir, 1)
-        first_done = _wait_for_log(output_dir, "completed file sync")
+        reader, writer = await server.accept(timeout=60)
+        expected = [
+            {"event": "log-subscriber-attached"},
+            {"event": "start file sync"},
+            {"event": "completed file sync"},
+        ]
+        await assert_event_sequence(reader, writer, expected)
+
         by_id = output_dir / "metadata" / "by-id"
-        wait_for(lambda: by_id.exists() and any(by_id.iterdir()), message="metadata")
+        assert by_id.exists() and any(by_id.iterdir())
         existing = {p.name for p in by_id.iterdir()}
         (workdir / "input" / "new.txt").write_text("new")
-        _wait_for_start_lines(output_dir, 2)
-        _wait_for_log(output_dir, "completed file sync", start=first_done + 1)
-        wait_for(
-            lambda: len(set(p.name for p in by_id.iterdir()) - existing) >= 1,
-            message="new file indexed",
-        )
+
+        expected = [
+            {"event": "start file sync"},
+            {"event": "completed file sync"},
+        ]
+        await assert_event_sequence(reader, writer, expected)
+        assert len(set(p.name for p in by_id.iterdir()) - existing) >= 1
     except Exception:
         dump_logs(compose_file, workdir)
         raise
@@ -46,3 +54,8 @@ def test_f1s2(tmp_path: Path) -> None:
             env_file=env_file,
             check=False,
         )
+        if writer is not None:
+            writer.close()
+            await writer.wait_closed()
+        server.close()
+        await server.wait_closed()

--- a/features/F1/tests/acceptance/test_s4.py
+++ b/features/F1/tests/acceptance/test_s4.py
@@ -3,29 +3,40 @@ from __future__ import annotations
 from pathlib import Path
 
 from shared import compose, compose_paths, dump_logs
+import pytest
 
-from .helpers import (
-    _write_env,
-    _prepare_dirs,
-    _wait_for_start_lines,
-    _expected_interval,
-)
+from .helpers import _write_env, _prepare_dirs, _expected_interval, _read_start_times
+from shared.acceptance import _start_server
+from shared.acceptance import assert_event_sequence
 
 
-def test_f1s4(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_f1s4(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
+    server, host, port = await _start_server()
     cron = "*/2 * * * * *"
-    _write_env(env_file, cron)
+    _write_env(env_file, cron, TEST="true", TEST_LOG_TARGET=f"http://{host}:{port}")
     _prepare_dirs(workdir, output_dir)
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    writer = None
     try:
-        times = _wait_for_start_lines(output_dir, 3)
+        reader, writer = await server.accept(timeout=60)
+        expected = [
+            {"event": "log-subscriber-attached"},
+            {"event": "start file sync"},
+            {"event": "completed file sync"},
+            {"event": "start file sync"},
+            {"event": "completed file sync"},
+            {"event": "start file sync"},
+        ]
+        await assert_event_sequence(reader, writer, expected)
         compose(compose_file, workdir, "stop", env_file=env_file)
+        times = _read_start_times(output_dir)
         interval = (times[-1] - times[-2]).total_seconds()
-        expected = _expected_interval(cron)
-        assert interval >= expected - 1
-        assert interval <= expected * 3 + 1
+        expected_interval = _expected_interval(cron)
+        assert interval >= expected_interval - 1
+        assert interval <= expected_interval * 3 + 1
     except Exception:
         dump_logs(compose_file, workdir)
         raise
@@ -40,3 +51,8 @@ def test_f1s4(tmp_path: Path) -> None:
             env_file=env_file,
             check=False,
         )
+        if writer is not None:
+            writer.close()
+            await writer.wait_closed()
+        server.close()
+        await server.wait_closed()

--- a/features/F1/tests/acceptance/test_s5.py
+++ b/features/F1/tests/acceptance/test_s5.py
@@ -3,31 +3,37 @@ from __future__ import annotations
 from pathlib import Path
 
 from shared import compose, compose_paths, dump_logs
+import pytest
 
-from .helpers import (
-    _write_env,
-    _prepare_dirs,
-    _wait_for_start_lines,
-    _wait_for_log,
-    _read_start_times,
-)
+from .helpers import _write_env, _prepare_dirs, _read_start_times
+from shared.acceptance import _start_server
+from shared.acceptance import assert_event_sequence
 
 
-def test_f1s5(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_f1s5(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
+    server, host, port = await _start_server()
     cron = "* * * * * *"
-    _write_env(env_file, cron)
+    _write_env(env_file, cron, TEST="true", TEST_LOG_TARGET=f"http://{host}:{port}")
     _prepare_dirs(workdir, output_dir)
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    writer = None
     try:
-        _wait_for_start_lines(output_dir, 1)
-        done_idx = _wait_for_log(output_dir, "completed file sync")
+        reader, writer = await server.accept(timeout=60)
+        expected = [
+            {"event": "log-subscriber-attached"},
+            {"event": "start file sync"},
+            {"event": "completed file sync"},
+        ]
+        await assert_event_sequence(reader, writer, expected)
+
         assert len(_read_start_times(output_dir)) == 1
-        _wait_for_start_lines(output_dir, 2)
-        assert done_idx < _wait_for_log(
-            output_dir, "start file sync", start=done_idx + 1
-        )
+        expected = [{"event": "start file sync"}]
+        await assert_event_sequence(reader, writer, expected)
+        times = _read_start_times(output_dir)
+        assert times[-1] > times[0]
     except Exception:
         dump_logs(compose_file, workdir)
         raise
@@ -42,3 +48,8 @@ def test_f1s5(tmp_path: Path) -> None:
             env_file=env_file,
             check=False,
         )
+        if writer is not None:
+            writer.close()
+            await writer.wait_closed()
+        server.close()
+        await server.wait_closed()

--- a/features/F1/tests/acceptance/test_s6.py
+++ b/features/F1/tests/acceptance/test_s6.py
@@ -3,25 +3,33 @@ from __future__ import annotations
 from pathlib import Path
 
 from shared import compose, compose_paths, dump_logs
+import pytest
 
-from .helpers import (
-    _write_env,
-    _prepare_dirs,
-    _wait_for_start_lines,
-    _read_start_times,
-    _expected_interval,
-)
+from .helpers import _write_env, _prepare_dirs, _read_start_times, _expected_interval
+from shared.acceptance import _start_server
+from shared.acceptance import assert_event_sequence
 
 
-def test_f1s6(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_f1s6(tmp_path: Path) -> None:
     compose_file, workdir, output_dir = compose_paths(__file__)
     env_file = tmp_path / ".env"
+    server, host, port = await _start_server()
     cron1 = "* * * * * *"
-    _write_env(env_file, cron1)
+    _write_env(env_file, cron1, TEST="true", TEST_LOG_TARGET=f"http://{host}:{port}")
     _prepare_dirs(workdir, output_dir)
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    writer = None
     try:
-        _wait_for_start_lines(output_dir, 2)
+        reader, writer = await server.accept(timeout=60)
+        expected = [
+            {"event": "log-subscriber-attached"},
+            {"event": "start file sync"},
+            {"event": "completed file sync"},
+            {"event": "start file sync"},
+            {"event": "completed file sync"},
+        ]
+        await assert_event_sequence(reader, writer, expected)
     except Exception:
         dump_logs(compose_file, workdir)
         raise
@@ -36,15 +44,28 @@ def test_f1s6(tmp_path: Path) -> None:
             env_file=env_file,
             check=False,
         )
+        if writer is not None:
+            writer.close()
+            await writer.wait_closed()
+        server.close()
+        await server.wait_closed()
     cron2 = "*/2 * * * * *"
-    _write_env(env_file, cron2)
+    server, host, port = await _start_server()
+    _write_env(env_file, cron2, TEST="true", TEST_LOG_TARGET=f"http://{host}:{port}")
     initial_count = len(_read_start_times(output_dir))
     compose(compose_file, workdir, "up", "-d", env_file=env_file)
+    writer = None
     try:
-        times = _wait_for_start_lines(output_dir, initial_count + 3)
+        reader, writer = await server.accept(timeout=60)
+        needed = initial_count + 3 - len(_read_start_times(output_dir))
+        expected = [{"event": "log-subscriber-attached"}] + (
+            [{"event": "start file sync"}, {"event": "completed file sync"}] * needed
+        )
+        await assert_event_sequence(reader, writer, expected)
+        times = _read_start_times(output_dir)
         interval = (times[-1] - times[-2]).total_seconds()
-        expected = _expected_interval(cron2)
-        assert abs(interval - expected) <= 1
+        expected_interval = _expected_interval(cron2)
+        assert abs(interval - expected_interval) <= 1
     except Exception:
         dump_logs(compose_file, workdir)
         raise
@@ -59,3 +80,8 @@ def test_f1s6(tmp_path: Path) -> None:
             env_file=env_file,
             check=False,
         )
+        if writer is not None:
+            writer.close()
+            await writer.wait_closed()
+        server.close()
+        await server.wait_closed()

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from features.F3 import archive
 from features.F4 import modules as modules_f4
 from features.F6 import server as f6_server
 from shared.logging_config import files_logger, setup_logging
+from shared.acceptance import acceptance_step
 
 DEBUG = str(os.environ.get("DEBUG", "False")) == "True"
 COMMIT_SHA = os.environ.get("COMMIT_SHA", "unknown")
@@ -24,6 +25,7 @@ duplicate_finder = duplicate_finder
 
 async def main() -> None:
     setup_logging()
+    acceptance_step("log-subscriber-attached")
     files_logger.info("running commit %s", COMMIT_SHA)
     await f1_sync.init_meili_and_sync()
     if modules_f4.is_modules_changed:

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -94,7 +94,8 @@ async def assert_event_sequence(
     expected: list[dict[str, Any]],
     timeout: float = 5,
 ) -> None:
-    """ACK every log record and assert that *expected* specs appear in order."""
+    """ACK each record and assert that *expected* specs appear in order."""
+    print("\n" + "=" * 30 + " acceptance events " + "=" * 30)
     idx = 0
     seen: list[str] = []
     try:
@@ -159,8 +160,10 @@ def acceptance_step(
 
 
 def dump_logs(compose_file: Path, workdir: Path) -> None:
-    """Print logs from all compose containers in service order."""
+    """Print logs from all compose containers in service order with separators."""
     for service in ("home-index", "meilisearch", "redis"):
+        header = f"\n{'=' * 30} {service} logs {'=' * 30}\n"
+        print(header, end="")
         result = subprocess.run(
             [
                 "docker",

--- a/shared/acceptance.py
+++ b/shared/acceptance.py
@@ -8,8 +8,154 @@ import sys
 import tempfile
 import time
 import urllib.request
+import urllib.parse
 from pathlib import Path
 from typing import Any, Callable
+import asyncio
+import pickle
+import struct
+
+# --- acceptance-test handshake ----------------------------------------------
+import logging
+from logging.handlers import SocketHandler
+import socket
+from shared.logging_config import files_logger
+
+ACCEPTANCE_LEVEL = logging.INFO + 5
+logging.addLevelName(ACCEPTANCE_LEVEL, "ACCEPTANCE")
+logging.Logger.acceptance = lambda self, m, *a, **k: self._log(  # type: ignore[attr-defined]
+    ACCEPTANCE_LEVEL, m, a, **k
+)
+
+_TEST = os.getenv("TEST", "").lower() == "true"
+_ACK = b"\x06"
+_sock: socket.socket | None = None
+
+
+class _AcceptServer:
+    def __init__(
+        self,
+        server: asyncio.AbstractServer,
+        q: asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]],
+    ) -> None:
+        self._server = server
+        self._q = q
+
+    async def accept(
+        self, timeout: float | None = None
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+        if timeout is None:
+            return await self._q.get()
+        return await asyncio.wait_for(self._q.get(), timeout)
+
+    def close(self) -> None:
+        self._server.close()
+
+    async def wait_closed(self) -> None:
+        await self._server.wait_closed()
+
+
+async def _start_server() -> tuple[_AcceptServer, str, int]:
+    """Return a TCP server and its address for log collection."""
+    q: asyncio.Queue[tuple[asyncio.StreamReader, asyncio.StreamWriter]] = (
+        asyncio.Queue()
+    )
+
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        q.put_nowait((r, w))
+
+    server = await asyncio.start_server(handler, host="0.0.0.0")
+    _, port = server.sockets[0].getsockname()
+    return _AcceptServer(server, q), "host.docker.internal", port
+
+
+async def _next_record(reader: asyncio.StreamReader) -> logging.LogRecord:
+    size_bytes = await reader.readexactly(4)
+    (size,) = struct.unpack(">I", size_bytes)
+    data = await reader.readexactly(size)
+    return logging.makeLogRecord(pickle.loads(data))
+
+
+def _matches(rec: logging.LogRecord, spec: dict[str, Any]) -> bool:
+    """Return True if *rec* matches all fields in *spec*."""
+    for key, want in spec.items():
+        got = getattr(rec, key, None)
+        if callable(want):
+            if not want(got):
+                return False
+        elif got != want:
+            return False
+    return True
+
+
+async def assert_event_sequence(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    expected: list[dict[str, Any]],
+    timeout: float = 5,
+) -> None:
+    """ACK every log record and assert that *expected* specs appear in order."""
+    idx = 0
+    seen: list[str] = []
+    try:
+        while idx < len(expected):
+            rec = await asyncio.wait_for(_next_record(reader), timeout)
+            msg = rec.getMessage()
+            seen.append(msg)
+            print(f"log event: {msg}")
+            writer.write(_ACK)
+            await writer.drain()
+            if _matches(rec, expected[idx]):
+                idx += 1
+    except Exception:
+        print("events received before error:", seen)
+        raise
+
+
+def _connect_once() -> None:
+    """Install SocketHandler and cache the socket for ACK exchange."""
+    global _sock
+    if _sock or not _TEST:
+        return
+    target = os.getenv("TEST_LOG_TARGET", "http://127.0.0.1:9020")
+    if "://" in target:
+        parsed = urllib.parse.urlparse(target)
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or 9020
+    else:
+        host, port_str = target.split(":")
+        port = int(port_str)
+    handler = SocketHandler(host, int(port))
+    handler.addFilter(lambda r: r.levelno == ACCEPTANCE_LEVEL)
+    root_logger = logging.getLogger()
+    if root_logger.level > ACCEPTANCE_LEVEL:
+        root_logger.setLevel(ACCEPTANCE_LEVEL)
+    try:
+        handler.sock = handler.makeSocket(timeout=5)
+    except OSError as exc:  # pragma: no cover - network failures
+        raise ConnectionError(
+            f"failed to connect to log server {host}:{port}: {exc}"
+        ) from exc
+    root_logger.addHandler(handler)
+    _sock = handler.sock
+
+
+def acceptance_step(
+    event: str,
+    *,
+    logger: logging.Logger | None = None,
+    **payload: Any,
+) -> None:
+    """Log *event* at the acceptance level and wait for an ACK when testing."""
+    _connect_once()
+    (logger or files_logger).log(
+        ACCEPTANCE_LEVEL,
+        event,
+        extra={"event": event, **payload},
+    )
+    if _TEST:
+        assert _sock is not None
+        _sock.recv(1)
 
 
 def dump_logs(compose_file: Path, workdir: Path) -> None:


### PR DESCRIPTION
## Summary
- install `pytest-asyncio` in the dev container so async acceptance tests run
- fix log server address so containers connect correctly
- pass `TEST` environment values to F1 acceptance containers so handshake succeeds
- raise an explicit error if the app fails to connect to the log server
- abort early in tests when the handshake fails so logs can be dumped
- map `host.docker.internal` for Linux containers and restore the log server helper
- make TEST environment variable always true and include scheme in TEST_LOG_TARGET
- parse TEST_LOG_TARGET as URL in the handshake logic
- allow timeout when accepting log server connections
- fail fast when log server unreachable
- refine F1 acceptance helpers and close log connections in finally blocks
- print each acceptance log event as tests run to aid debugging

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68812dd9fc70832bab65d493978aa2f0