### PR TITLE
Fix cron validation and logging setup

### DIFF
--- a/features/F1/scheduler.py
+++ b/features/F1/scheduler.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
-from apscheduler.triggers.interval import IntervalTrigger
+
 
 from shared.logging_config import files_logger
 
@@ -38,16 +38,13 @@ def parse_cron_env(
     )
 
 
-def attach_sync_job(
-    scheduler: BackgroundScheduler, debug: bool, run_fn: Callable[[], None]
-) -> None:
-    """Attach the periodic sync job to the scheduler."""
-    try:
-        trigger = (
-            IntervalTrigger(seconds=60) if debug else CronTrigger(**parse_cron_env())
-        )
-    except ValueError:
-        files_logger.error("invalid cron expression")
-        raise
+try:
+    CRON_KWARGS = parse_cron_env()
+except ValueError:
+    files_logger.error("invalid cron expression")
+    raise
 
-    scheduler.add_job(run_fn, trigger, max_instances=1)
+
+def attach_sync_job(scheduler: BackgroundScheduler, run_fn: Callable[[], None]) -> None:
+    """Attach the periodic sync job to the scheduler."""
+    scheduler.add_job(run_fn, CronTrigger(**CRON_KWARGS), max_instances=1)

--- a/features/F1/sync.py
+++ b/features/F1/sync.py
@@ -460,14 +460,11 @@ async def init_meili_and_sync() -> None:
     await sync_documents()
 
 
-async def schedule_and_run(
-    api_coro_fn: Callable[[], Awaitable[Any]], *, debug: bool
-) -> None:
+async def schedule_and_run(api_coro_fn: Callable[[], Awaitable[Any]]) -> None:
     """Run the API server and schedule periodic sync jobs."""
     sched = BackgroundScheduler()
     scheduler.attach_sync_job(
         sched,
-        debug,
         lambda: run_in_process(init_meili_and_sync),
     )
     sched.start()

--- a/features/F1/tests/unit/test_schedule.py
+++ b/features/F1/tests/unit/test_schedule.py
@@ -49,7 +49,6 @@ def test_scheduler_attaches_a_crontrigger_job_for_periodic_indexing(
     monkeypatch.setenv(
         "MODULES_CONFIG_FILE_PATH", str(tmp_path / "modules_config.json")
     )
-    monkeypatch.delenv("DEBUG", raising=False)
     added = {}
 
     class DummyScheduler:

--- a/features/F4/home_index_module/run_server.py
+++ b/features/F4/home_index_module/run_server.py
@@ -52,10 +52,6 @@ def setup_debugger() -> None:
 
 setup_debugger()
 
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
-)
-
 LOGGING_LEVEL = os.environ.get("LOGGING_LEVEL", "INFO")
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
 QUEUE_NAME = os.environ.get("QUEUE_NAME", "module")

--- a/main.py
+++ b/main.py
@@ -1,14 +1,16 @@
 import asyncio
 import os
 
-from features.F1 import sync as f1_sync
-from features.F2 import migrations, duplicate_finder
-from features.F3 import archive
-from features.F4 import modules as modules_f4
-from features.F6 import server as f6_server
 from shared.logging_config import files_logger, setup_logging
 
-DEBUG = str(os.environ.get("DEBUG", "False")) == "True"
+setup_logging()
+
+from features.F1 import sync as f1_sync  # noqa: E402
+from features.F2 import migrations, duplicate_finder  # noqa: E402
+from features.F3 import archive  # noqa: E402
+from features.F4 import modules as modules_f4  # noqa: E402
+from features.F6 import server as f6_server  # noqa: E402
+
 COMMIT_SHA = os.environ.get("COMMIT_SHA", "unknown")
 
 # re-export helpers used by legacy tests
@@ -23,7 +25,6 @@ duplicate_finder = duplicate_finder
 
 
 async def main() -> None:
-    setup_logging()
     files_logger.info("running commit %s", COMMIT_SHA)
     await f1_sync.init_meili_and_sync()
     if modules_f4.is_modules_changed:
@@ -31,7 +32,7 @@ async def main() -> None:
         await f1_sync.init_meili_and_sync()
         modules_f4.save_modules_state()
     await asyncio.gather(
-        f1_sync.schedule_and_run(f6_server.serve_api, debug=DEBUG),
+        f1_sync.schedule_and_run(f6_server.serve_api),
         modules_f4.service_module_queues(),
     )
 


### PR DESCRIPTION
## Summary
- set up logging before importing other modules
- remove DEBUG support from scheduling
- validate cron expression at module load
- drop extra logging configuration in run_server
- adjust unit tests

## Testing
- `bash check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885529c37f8832b8f3ee3b495c460cf