### PR TITLE
Fix F1S6 env var timing

### DIFF
--- a/features/F1/tests/acceptance/s6/test_s6.py
+++ b/features/F1/tests/acceptance/s6/test_s6.py
@@ -46,12 +46,12 @@ async def test_f1s6(tmp_path: Path, docker_client, request):
         CONTAINER_NAMES,
         request=request,
     ) as watchers:
+        os.environ["CRON_EXPRESSION"] = "* * * * * *"
         async with compose_up(
             compose_file,
             watchers=watchers,
         ):
             # first run with cron1
-            os.environ["CRON_EXPRESSION"] = "* * * * * *"
             await watchers["f1s6_home-index"].wait_for_sequence(
                 [
                     EventMatcher("start file sync"),
@@ -83,3 +83,4 @@ async def test_f1s6(tmp_path: Path, docker_client, request):
     interval = events[-1].ts - events[-2].ts
     expected = _expected_interval("*/2 * * * * *")
     assert abs(interval - expected) <= 1
+    os.environ.pop("CRON_EXPRESSION", None)


### PR DESCRIPTION
## Summary
- fix F1S6 acceptance test to set cron env before starting containers

## Testing
- `bash check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886369b74a0832b93ae2cd3f611bdad