### PR TITLE
Fix F1 acceptance test cleanup

### DIFF
--- a/features/F1/tests/acceptance/s2/test_s2.py
+++ b/features/F1/tests/acceptance/s2/test_s2.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import List
-
 import docker
 import pytest
 
@@ -16,10 +14,8 @@ from shared.acceptance_helpers import (
     make_watchers,
 )
 
-CONTAINER_NAMES: List[str] = [
-    "f1s2_home-index",
-    "f1s2_meilisearch",
-]
+HOME_INDEX_CONTAINER_NAME = "f1s2_home-index"
+MEILI_CONTAINER_NAME = "f1s2_meilisearch"
 
 
 @pytest.fixture(autouse=True)
@@ -41,46 +37,44 @@ def docker_client():
 async def test_f1s2(tmp_path: Path, docker_client, request):
     compose_file, workdir, output_dir = compose_paths_for_test(__file__)
 
-    async with make_watchers(
-        docker_client,
-        CONTAINER_NAMES,
-        request=request,
-    ) as watchers:
-        async with compose_up(
-            compose_file,
-            watchers=watchers,
-        ):
-            await watchers["f1s2_home-index"].wait_for_sequence(
-                [
-                    EventMatcher("start file sync"),
-                    EventMatcher("completed file sync"),
-                ],
-                timeout=120,
-            )
-
-            (workdir / "input" / "new.txt").write_text("new")
-
-            await watchers["f1s2_home-index"].wait_for_sequence(
-                [
-                    EventMatcher("start file sync"),
-                    EventMatcher("commit changes to meilisearch"),
-                    EventMatcher("completed file sync"),
-                ],
-                timeout=120,
-            )
-        for w in watchers.values():
-            w.assert_no_line(lambda line: "ERROR" in line)
-
-    doc_id = assert_file_indexed(workdir, output_dir, "new.txt")
-
     async with compose_up(
         compose_file,
-        watchers=watchers,
-        containers=["f1s2_meilisearch"],
+        containers=[MEILI_CONTAINER_NAME],
     ):
+        async with make_watchers(
+            docker_client,
+            [HOME_INDEX_CONTAINER_NAME],
+            request=request,
+        ) as watchers:
+            async with compose_up(
+                compose_file,
+                watchers=watchers,
+                containers=[HOME_INDEX_CONTAINER_NAME],
+            ):
+                await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
+                    [
+                        EventMatcher("start file sync"),
+                        EventMatcher("completed file sync"),
+                    ],
+                    timeout=10,
+                )
+
+                (workdir / "input" / "new.txt").write_text("new")
+
+                await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
+                    [
+                        EventMatcher("start file sync"),
+                        EventMatcher("commit changes to meilisearch"),
+                        EventMatcher("completed file sync"),
+                    ],
+                    timeout=10,
+                )
+            for w in watchers.values():
+                w.assert_no_line(lambda line: "ERROR" in line)
+
+            doc_id = assert_file_indexed(workdir, output_dir, "new.txt")
+
         docs = await asyncio.to_thread(
             search_meili, compose_file, workdir, f'id = "{doc_id}"'
         )
         assert docs
-    for w in watchers.values():
-        w.assert_no_line(lambda line: "ERROR" in line)

--- a/features/F1/tests/acceptance/s3/test_s3.py
+++ b/features/F1/tests/acceptance/s3/test_s3.py
@@ -59,22 +59,22 @@ async def test_f1s3(tmp_path: Path, docker_client, request):
                     timeout=10,
                 )
 
-            existing = set((output_dir / "metadata" / "by-id").iterdir())
-            hello = workdir / "input" / "hello.txt"
-            hello.write_text("changed")
+                existing = set((output_dir / "metadata" / "by-id").iterdir())
+                hello = workdir / "input" / "hello.txt"
+                hello.write_text("changed")
 
-            await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
-                [
-                    EventMatcher("start file sync"),
-                    EventMatcher("completed file sync"),
-                ],
-                timeout=10,
-            )
-            for w in watchers.values():
-                w.assert_no_line(lambda line: "ERROR" in line)
+                await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
+                    [
+                        EventMatcher("start file sync"),
+                        EventMatcher("completed file sync"),
+                    ],
+                    timeout=10,
+                )
+                for w in watchers.values():
+                    w.assert_no_line(lambda line: "ERROR" in line)
 
-            new_id = assert_file_indexed(workdir, output_dir, "hello.txt")
-            assert any(p.name != new_id for p in existing)
+                new_id = assert_file_indexed(workdir, output_dir, "hello.txt")
+                assert any(p.name != new_id for p in existing)
 
         docs = await asyncio.to_thread(
             search_meili, compose_file, workdir, f'id = "{new_id}"'

--- a/features/F1/tests/acceptance/s3/test_s3.py
+++ b/features/F1/tests/acceptance/s3/test_s3.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import List
-
 import docker
 import pytest
 
@@ -16,10 +14,8 @@ from shared.acceptance_helpers import (
     make_watchers,
 )
 
-CONTAINER_NAMES: List[str] = [
-    "f1s3_home-index",
-    "f1s3_meilisearch",
-]
+HOME_INDEX_CONTAINER_NAME = "f1s3_home-index"
+MEILI_CONTAINER_NAME = "f1s3_meilisearch"
 
 
 @pytest.fixture(autouse=True)
@@ -41,48 +37,46 @@ def docker_client():
 async def test_f1s3(tmp_path: Path, docker_client, request):
     compose_file, workdir, output_dir = compose_paths_for_test(__file__)
 
-    async with make_watchers(
-        docker_client,
-        CONTAINER_NAMES,
-        request=request,
-    ) as watchers:
-        async with compose_up(
-            compose_file,
-            watchers=watchers,
-        ):
-            await watchers["f1s3_home-index"].wait_for_sequence(
-                [
-                    EventMatcher("start file sync"),
-                    EventMatcher("completed file sync"),
-                ],
-                timeout=120,
-            )
+    async with compose_up(
+        compose_file,
+        containers=[MEILI_CONTAINER_NAME],
+    ):
+        async with make_watchers(
+            docker_client,
+            [HOME_INDEX_CONTAINER_NAME],
+            request=request,
+        ) as watchers:
+            async with compose_up(
+                compose_file,
+                watchers=watchers,
+                containers=[HOME_INDEX_CONTAINER_NAME],
+            ):
+                await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
+                    [
+                        EventMatcher("start file sync"),
+                        EventMatcher("completed file sync"),
+                    ],
+                    timeout=10,
+                )
 
             existing = set((output_dir / "metadata" / "by-id").iterdir())
             hello = workdir / "input" / "hello.txt"
             hello.write_text("changed")
 
-            await watchers["f1s3_home-index"].wait_for_sequence(
+            await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
                 [
                     EventMatcher("start file sync"),
                     EventMatcher("completed file sync"),
                 ],
-                timeout=120,
+                timeout=10,
             )
-        for w in watchers.values():
-            w.assert_no_line(lambda line: "ERROR" in line)
+            for w in watchers.values():
+                w.assert_no_line(lambda line: "ERROR" in line)
 
-    new_id = assert_file_indexed(workdir, output_dir, "hello.txt")
-    assert any(p.name != new_id for p in existing)
+            new_id = assert_file_indexed(workdir, output_dir, "hello.txt")
+            assert any(p.name != new_id for p in existing)
 
-    async with compose_up(
-        compose_file,
-        watchers=watchers,
-        containers=["f1s3_meilisearch"],
-    ):
         docs = await asyncio.to_thread(
             search_meili, compose_file, workdir, f'id = "{new_id}"'
         )
         assert docs
-    for w in watchers.values():
-        w.assert_no_line(lambda line: "ERROR" in line)

--- a/features/F1/tests/acceptance/s4/test_s4.py
+++ b/features/F1/tests/acceptance/s4/test_s4.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
 
 import docker
 import pytest
@@ -15,7 +14,7 @@ from shared.acceptance_helpers import (
 
 from ..helpers import _expected_interval
 
-CONTAINER_NAMES: List[str] = ["f1s4_home-index"]
+HOME_INDEX_CONTAINER_NAME = "f1s4_home-index"
 
 
 @pytest.fixture(autouse=True)
@@ -39,20 +38,20 @@ async def test_f1s4(tmp_path: Path, docker_client, request):
 
     async with make_watchers(
         docker_client,
-        CONTAINER_NAMES,
+        [HOME_INDEX_CONTAINER_NAME],
         request=request,
     ) as watchers:
         async with compose_up(
             compose_file,
             watchers=watchers,
         ):
-            events = await watchers["f1s4_home-index"].wait_for_sequence(
+            events = await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
                 [
                     EventMatcher("start file sync"),
                     EventMatcher("start file sync"),
                     EventMatcher("start file sync"),
                 ],
-                timeout=120,
+                timeout=10,
             )
         for w in watchers.values():
             w.assert_no_line(lambda line: "ERROR" in line)

--- a/features/F1/tests/acceptance/s5/test_s5.py
+++ b/features/F1/tests/acceptance/s5/test_s5.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
 
 import docker
 import pytest
@@ -13,7 +12,7 @@ from shared.acceptance_helpers import (
     make_watchers,
 )
 
-CONTAINER_NAMES: List[str] = ["f1s5_home-index"]
+HOME_INDEX_CONTAINER_NAME = "f1s5_home-index"
 
 
 @pytest.fixture(autouse=True)
@@ -37,20 +36,20 @@ async def test_f1s5(tmp_path: Path, docker_client, request):
 
     async with make_watchers(
         docker_client,
-        CONTAINER_NAMES,
+        [HOME_INDEX_CONTAINER_NAME],
         request=request,
     ) as watchers:
         async with compose_up(
             compose_file,
             watchers=watchers,
         ):
-            events = await watchers["f1s5_home-index"].wait_for_sequence(
+            events = await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
                 [
                     EventMatcher("start file sync"),
                     EventMatcher("completed file sync"),
                     EventMatcher("start file sync"),
                 ],
-                timeout=120,
+                timeout=10,
             )
         for w in watchers.values():
             w.assert_no_line(lambda line: "ERROR" in line)

--- a/features/F1/tests/acceptance/s7/test_s7.py
+++ b/features/F1/tests/acceptance/s7/test_s7.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
 
 import docker
 import pytest
@@ -13,10 +12,7 @@ from shared.acceptance_helpers import (
     make_watchers,
 )
 
-CONTAINER_NAMES: List[str] = [
-    "f1s7_home-index",
-    "f1s7_meilisearch",
-]
+HOME_INDEX_CONTAINER_NAME = "f1s7_home-index"
 
 
 @pytest.fixture(autouse=True)
@@ -40,19 +36,19 @@ async def test_f1s7(tmp_path: Path, docker_client, request):
 
     async with make_watchers(
         docker_client,
-        CONTAINER_NAMES,
+        [HOME_INDEX_CONTAINER_NAME],
         request=request,
     ) as watchers:
         async with compose_up(
             compose_file,
             watchers=watchers,
         ):
-            await watchers["f1s7_home-index"].wait_for_sequence(
+            await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
                 [
                     EventMatcher("start file sync"),
                     EventMatcher("start file sync"),
                 ],
-                timeout=120,
+                timeout=10,
             )
         for w in watchers.values():
             w.assert_no_line(lambda line: "ERROR" in line)
@@ -63,11 +59,11 @@ async def test_f1s7(tmp_path: Path, docker_client, request):
             compose_file,
             watchers=watchers,
         ):
-            await watchers["f1s7_home-index"].wait_for_sequence(
+            await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_sequence(
                 [
                     EventMatcher("start file sync"),
                 ],
-                timeout=120,
+                timeout=10,
             )
         for w in watchers.values():
             w.assert_no_line(lambda line: "ERROR" in line)

--- a/features/F1/tests/acceptance/s8/test_s8.py
+++ b/features/F1/tests/acceptance/s8/test_s8.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
 
 import docker
 import pytest
@@ -12,10 +11,7 @@ from shared.acceptance_helpers import (
     make_watchers,
 )
 
-CONTAINER_NAMES: List[str] = [
-    "f1s8_home-index",
-    "f1s8_meilisearch",
-]
+HOME_INDEX_CONTAINER_NAME = "f1s8_home-index"
 
 
 @pytest.fixture(autouse=True)
@@ -39,14 +35,14 @@ async def test_f1s8(tmp_path: Path, docker_client, request):
 
     async with make_watchers(
         docker_client,
-        CONTAINER_NAMES,
+        [HOME_INDEX_CONTAINER_NAME],
         request=request,
     ) as watchers:
         async with compose_up(
             compose_file,
             watchers=watchers,
         ):
-            await watchers["f1s8_home-index"].wait_for_line(
-                "invalid cron expression", timeout=5
+            await watchers[HOME_INDEX_CONTAINER_NAME].wait_for_line(
+                "invalid cron expression", timeout=10
             )
-        watchers["f1s8_home-index"].assert_no_line("start file sync")
+        watchers[HOME_INDEX_CONTAINER_NAME].assert_no_line("start file sync")


### PR DESCRIPTION
## Summary
- keep container name constants per test
- run searches only after stopping Home-Index
- ensure error checks occur after containers stop
- clean up CRON_EXPRESSION with try/finally
- start Meilisearch once per scenario

## Testing
- `./check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68863a34b224832ba7f7e9f2d6d000b4