### PR TITLE
Attach watchers to all containers in F1 tests

### DIFF
--- a/features/F1/tests/acceptance/s1/test_s1.py
+++ b/features/F1/tests/acceptance/s1/test_s1.py
@@ -35,15 +35,16 @@ def docker_client():
 async def test_f1s1(tmp_path: Path, docker_client, request):
     compose_file, workdir, output_dir = compose_paths_for_test(__file__)
 
-    async with compose_up(
-        compose_file,
-        containers=[MEILI_CONTAINER_NAME],
-    ):
-        async with make_watchers(
-            docker_client,
-            [HOME_INDEX_CONTAINER_NAME],
-            request=request,
-        ) as watchers:
+    async with make_watchers(
+        docker_client,
+        [HOME_INDEX_CONTAINER_NAME, MEILI_CONTAINER_NAME],
+        request=request,
+    ) as watchers:
+        async with compose_up(
+            compose_file,
+            watchers=watchers,
+            containers=[MEILI_CONTAINER_NAME],
+        ):
             async with compose_up(
                 compose_file,
                 watchers=watchers,
@@ -62,12 +63,13 @@ async def test_f1s1(tmp_path: Path, docker_client, request):
                     ],
                     timeout=10,
                 )
-            for w in watchers.values():
-                w.assert_no_line(lambda line: "ERROR" in line)
-
             doc_id = assert_file_indexed(workdir, output_dir, "hello.txt")
-
-        docs = await asyncio.to_thread(
-            search_meili, compose_file, workdir, f'id = "{doc_id}"'
-        )
-        assert docs
+            docs = await asyncio.to_thread(
+                search_meili,
+                compose_file,
+                workdir,
+                f'id = "{doc_id}"',
+            )
+            assert docs
+        for w in watchers.values():
+            w.assert_no_line(lambda line: "ERROR" in line)

--- a/features/F1/tests/acceptance/s5/test_s5.py
+++ b/features/F1/tests/acceptance/s5/test_s5.py
@@ -13,6 +13,7 @@ from shared.acceptance_helpers import (
 )
 
 HOME_INDEX_CONTAINER_NAME = "f1s5_home-index"
+MEILI_CONTAINER_NAME = "f1s5_meilisearch"
 
 
 @pytest.fixture(autouse=True)
@@ -36,7 +37,7 @@ async def test_f1s5(tmp_path: Path, docker_client, request):
 
     async with make_watchers(
         docker_client,
-        [HOME_INDEX_CONTAINER_NAME],
+        [HOME_INDEX_CONTAINER_NAME, MEILI_CONTAINER_NAME],
         request=request,
     ) as watchers:
         async with compose_up(
@@ -51,7 +52,6 @@ async def test_f1s5(tmp_path: Path, docker_client, request):
                 ],
                 timeout=10,
             )
+        assert events[1].ts < events[2].ts
         for w in watchers.values():
             w.assert_no_line(lambda line: "ERROR" in line)
-
-    assert events[1].ts < events[2].ts

--- a/features/F1/tests/acceptance/s7/test_s7.py
+++ b/features/F1/tests/acceptance/s7/test_s7.py
@@ -13,6 +13,7 @@ from shared.acceptance_helpers import (
 )
 
 HOME_INDEX_CONTAINER_NAME = "f1s7_home-index"
+MEILI_CONTAINER_NAME = "f1s7_meilisearch"
 
 
 @pytest.fixture(autouse=True)
@@ -36,7 +37,7 @@ async def test_f1s7(tmp_path: Path, docker_client, request):
 
     async with make_watchers(
         docker_client,
-        [HOME_INDEX_CONTAINER_NAME],
+        [HOME_INDEX_CONTAINER_NAME, MEILI_CONTAINER_NAME],
         request=request,
     ) as watchers:
         async with compose_up(
@@ -50,9 +51,6 @@ async def test_f1s7(tmp_path: Path, docker_client, request):
                 ],
                 timeout=10,
             )
-        for w in watchers.values():
-            w.assert_no_line(lambda line: "ERROR" in line)
-
         initial_lines = (output_dir / "files.log").read_text().splitlines()
 
         async with compose_up(
@@ -65,8 +63,7 @@ async def test_f1s7(tmp_path: Path, docker_client, request):
                 ],
                 timeout=10,
             )
-        for w in watchers.values():
-            w.assert_no_line(lambda line: "ERROR" in line)
-
         final_lines = (output_dir / "files.log").read_text().splitlines()
         assert len(final_lines) > len(initial_lines)
+        for w in watchers.values():
+            w.assert_no_line(lambda line: "ERROR" in line)

--- a/features/F1/tests/acceptance/s8/test_s8.py
+++ b/features/F1/tests/acceptance/s8/test_s8.py
@@ -12,6 +12,7 @@ from shared.acceptance_helpers import (
 )
 
 HOME_INDEX_CONTAINER_NAME = "f1s8_home-index"
+MEILI_CONTAINER_NAME = "f1s8_meilisearch"
 
 
 @pytest.fixture(autouse=True)
@@ -35,7 +36,7 @@ async def test_f1s8(tmp_path: Path, docker_client, request):
 
     async with make_watchers(
         docker_client,
-        [HOME_INDEX_CONTAINER_NAME],
+        [HOME_INDEX_CONTAINER_NAME, MEILI_CONTAINER_NAME],
         request=request,
     ) as watchers:
         async with compose_up(
@@ -46,3 +47,4 @@ async def test_f1s8(tmp_path: Path, docker_client, request):
                 "invalid cron expression", timeout=10
             )
         watchers[HOME_INDEX_CONTAINER_NAME].assert_no_line("start file sync")
+        watchers[MEILI_CONTAINER_NAME].assert_no_line(lambda line: "ERROR" in line)


### PR DESCRIPTION
## Summary
- always attach log watchers for every F1 container
- verify watcher logs just before closing them
- keep search_meili calls inside running containers
- remove duplicate watcher checks
- move file assertions to after home-index shuts down

## Testing
- `bash check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688647508fb8832ba4b2ac51ddbac10d