### PR TITLE
Convert F1 scenarios to gherkin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ treat it as a raw GitHub Actions log from a failed CI run and follow this flow
 * One markdown file per feature in `features/Fx/`, named `SPEC.md`.
 * Contains an `Acceptance` section - which is always the master feature specification.
 * Always link each `Acceptance` scenario to corresponding acceptance test files.
+* Present each `Acceptance` scenario as a tagged Gherkin block in Markdown. Each scenario must represent an important testable requirement of the feature.
 * Always match existing format and style when editing.
 
 ### S2.3\_REPOSITORY\_LAYOUT


### PR DESCRIPTION
## Summary
- rewrite feature F1 spec scenarios in gherkin format
- clarify that F1 tests only need to pass in container environment
- document gherkin scenario style requirement in AGENTS guidelines
- address inline review comments

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6886e31778d0832bb93f2dab30942676