### PR TITLE
Rewrite F2 spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,17 @@ treat it as a raw GitHub Actions log from a failed CI run and follow this flow
 * Contains an `Acceptance` section - which is always the master feature specification.
 * Always link each `Acceptance` scenario to corresponding acceptance test files.
 * Present each `Acceptance` scenario as a tagged Gherkin block in Markdown. Each scenario must represent an important testable requirement of the feature.
-* Always match existing format and style when editing.
+* Specify the exact expected log sequence(s) for every scenario,
+  capturing the chronological milestones from startup through each
+  assertion. Use multiple ordered sequences when needed, keeping them
+  as sparse as possible while still including every meaningful event
+  leading up to the assertions.
+  Sequences must lead from initial boot up to every assertion in order.
+* When logs from a prior action are relevant, begin the corresponding
+  `When` block with that log sequence.
+* Use logs as the marker of elapsed time; avoid separate steps such as
+  "the next tick runs".
+* Always match existing format and style when editing non‑Acceptance sections.
 
 ### S2.3\_REPOSITORY\_LAYOUT
 


### PR DESCRIPTION
## Summary
- clarify that logs mark passage of time in AGENTS guidelines
- keep `Index file added between ticks` to a single `When` step
- drop explicit tick steps from F2 scenarios and use present-tense `When`
- fix F1 scenario chronology
- confirm each file becomes searchable when a new file is indexed
- address review feedback

## Testing
- `./check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6889142b9408832b82fcb93af5c7ead0